### PR TITLE
Adds modular command line argument interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ jdk:
   - openjdk7
 os:
   - linux
-  - osx

--- a/README.md
+++ b/README.md
@@ -24,35 +24,68 @@ To use the program, open a command-line and try out the following command (repla
 
 ```bash
 $ java -jar db-preservation-toolkit-x.y.z-jar-with-dependencies.jar 
-Synopsys: java -jar db-preservation-toolkit.jar -i IMPORT_MODULE [options...] -o EXPORT_MODULE [options...]
-Available import modules:
-	SIARD1 dir
-	SQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt
-	PostgreSQLJDBC hostName [port] database username password encrypt
-	MySQLJDBC hostName [port] database username password
-	DB2JDBC hostname port database username password
-	Oracle12c hostName port database username password
-	MSAccessUCanAccess database.mdb|accdb
-	DBML baseDir
-Available export modules:
-	SIARD1 dir [compress]
-	SQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt
-	PostgreSQLJDBC [port] hostName database username password encrypt
-	MySQLJDBC hostName [port] database username password
-	DB2JDBC hostname port database username password
-	PhpMyAdmin hostName [port] database username password
-	DBML baseDir
+Usage: dbptk <importModule> [import module options] <exportModule> [export module options]
+
+## Available import modules: -i <module>, --import=module
+
+Import module: MySQLJDBC
+    -ih, --ihostname=value    (required) the hostname of the MySQL server
+    -idb, --idatabase=value    (required) the name of the database to import from
+    -iu, --iusername=value    (required) the name of the user to use in connection
+    -ip, --ipassword=value    (required) the password of the user to use in connection
+    -ipn, --iport-number=value    (optional) the port that the MySQL server is listening
+
+Import module: PostgreSQLJDBC
+    -ih, --ihostname=value    (required) the name of the PostgreSQL server host (e.g. localhost)
+    -idb, --idatabase=value    (required) the name of the database to connect to
+    -iu, --iusername=value    (required) the name of the user to use in connection
+    -ip, --ipassword=value    (required) the password of the user to use in connection
+    -ide, --idisable-encryption    (optional) use to turn off encryption in the connection
+    -ipn, --iport-number=value    (optional) the port of where the PostgreSQL server is listening, default is 5432
+
+Import module: SIARD1
+    -if, --ifile=value    (required) Path to SIARD1 archive file
+
+Import module: SIARD2
+    -if, --ifile=value    (required) Path to SIARD2 archive file
+
+## Available export modules: -e <module>, --export=module
+
+Export module: MySQLJDBC
+    -eh, --ehostname=value    (required) the hostname of the MySQL server
+    -edb, --edatabase=value    (required) the name of the database to import from
+    -eu, --eusername=value    (required) the name of the user to use in connection
+    -ep, --epassword=value    (required) the password of the user to use in connection
+    -epn, --eport-number=value    (optional) the port that the MySQL server is listening
+
+Export module: PostgreSQLJDBC
+    -eh, --ehostname=value    (required) the name of the PostgreSQL server host (e.g. localhost)
+    -edb, --edatabase=value    (required) the name of the database to connect to
+    -eu, --eusername=value    (required) the name of the user to use in connection
+    -ep, --epassword=value    (required) the password of the user to use in connection
+    -ede, --edisable-encryption    (optional) use to turn off encryption in the connection
+    -epn, --eport-number=value    (optional) the port of where the PostgreSQL server is listening, default is 5432
+
+Export module: SIARD1
+    -ef, --efile=value    (required) Path to SIARD1 archive file
+    -ec, --ecompress    (optional) use to compress the SIARD1 archive file with deflate method
+    -ep, --epretty-xml    (optional) write human-readable XML
+
+Export module: SIARD2
+    -ef, --efile=value    (required) Path to SIARD2 archive file
+    -ec, --ecompress    (optional) use to compress the SIARD2 archive file with deflate method
+    -ep, --epretty-xml    (optional) write human-readable XML
 ```
 
 You have to select an input and an output module, providing for each its configuration.
 
 
-For example, if you want to connect to a live MySQL database and export its content to DBML format, you can use the following command.
+For example, if you want to connect to a live MySQL database and export its content to SIARD 1.0 format, you can use the following command.
 
 ```bash
 $ java -jar db-preservation-toolkit-x.y.z-jar-with-dependencies.jar \
--i MySQLJDBC localhost example_db username p4ssw0rd \
--o SIARD example_db_siard_export
+-i MySQLJDBC -ihostname=localhost -idb example_db -iu username -ip p4ssw0rd \
+-o SIARD1 example.siard
 ```
 
 ## How to build from source

--- a/pom.xml
+++ b/pom.xml
@@ -423,11 +423,6 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-integration</artifactId>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
             <groupId>ch.admin.bar</groupId>
             <artifactId>siard1-jaxb</artifactId>
             <version>${siard1.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,11 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-integration</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
             <groupId>ch.admin.bar</groupId>
             <artifactId>siard1-jaxb</artifactId>
             <version>${siard1.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -536,5 +536,10 @@
             <artifactId>solr-core</artifactId>
             <version>4.10.0</version>
         </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/databasepreservation/Main.java
+++ b/src/main/java/com/databasepreservation/Main.java
@@ -22,23 +22,12 @@ import com.databasepreservation.modules.siard.out.output.SIARD2ExportModule;
 import com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory;
 import com.databasepreservation.modules.sqlServer.in.SQLServerJDBCImportModule;
 import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionGroup;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -91,7 +80,7 @@ public class Main {
                                 if (e.getCause() != null && e.getCause() instanceof ClassNotFoundException && e
                                   .getCause().getMessage().equals("sun.jdbc.odbc.JdbcOdbcDriver")) {
                                         logger.error("Could not find the Java ODBC driver, "
-                                            + "please run this program under Windows " + "to use the JDBC-ODBC bridge.",
+                                            + "please run this program under Windows to use the JDBC-ODBC bridge.",
                                           e.getCause());
                                 } else if (e.getModuleErrors() != null) {
                                         for (Map.Entry<String, Throwable> entry : e.getModuleErrors().entrySet()) {
@@ -383,38 +372,38 @@ public class Main {
         }
 
         private static void printHelp() {
-//                new HelpFormatter().printHelp(80, "dbptk", "\nModule Options:", commandLineOptions, null, true);
+                //                new HelpFormatter().printHelp(80, "dbptk", "\nModule Options:", commandLineOptions, null, true);
 
-//                System.out.println("Synopsys: java -jar " + NAME + ".jar" + " -i IMPORT_MODULE [options...]"
-//                  + " -o EXPORT_MODULE [options...]");
-//                System.out.println("Available import modules:");
-//                System.out.println("\tSIARD dir compress|store");
-//                System.out.println(
-//                  "\tSQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt");
-//                System.out.println("\tPostgreSQLJDBC hostName [port] database username password encrypt");
-//                System.out.println("\tMySQLJDBC hostName [port] database username password");
-//                System.out.println("\tDB2JDBC hostname port database username password");
-//                System.out.println("\tOracle12c hostName port database username password");
-//                //		System.out.println("\tMSAccess database.mdb|accdb");
-//                System.out.println("\tMSAccessUCanAccess database.mdb|accdb");
-//                // System.out.println("\tODBC source [username password]");
-//                System.out.println("\tDBML baseDir");
-//
-//                System.out.println("Available export modules:");
-//                System.out.println("\tSIARD dir");
-//                System.out.println(
-//                  "\tSQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt");
-//                System.out.println("\tPostgreSQLJDBC [port] hostName database username password encrypt");
-//                System.out.println("\tMySQLJDBC hostName [port] database username password");
-//                System.out.println("\tDB2JDBC hostname port database username password");
-//                System.out.println("\tPhpMyAdmin hostName [port] database username password");
-//                System.out.println("\tDBML baseDir");
-//                //		System.out
-//                //				.println("\tPostgreSQLFile sqlFile <- SQL file optimized for PostgreSQL");
-//                //		System.out
-//                //				.println("\tMySQLFile sqlFile <- SQL file optimized for MySQL");
-//                //		System.out
-//                //				.println("\tSQLServerFile sqlFile <- SQL file optimized for SQL Server");
-//                //		System.out.println("\tGenericSQLFile sqlFile <- generic SQL file");
+                //                System.out.println("Synopsys: java -jar " + NAME + ".jar" + " -i IMPORT_MODULE [options...]"
+                //                  + " -o EXPORT_MODULE [options...]");
+                //                System.out.println("Available import modules:");
+                //                System.out.println("\tSIARD dir compress|store");
+                //                System.out.println(
+                //                  "\tSQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt");
+                //                System.out.println("\tPostgreSQLJDBC hostName [port] database username password encrypt");
+                //                System.out.println("\tMySQLJDBC hostName [port] database username password");
+                //                System.out.println("\tDB2JDBC hostname port database username password");
+                //                System.out.println("\tOracle12c hostName port database username password");
+                //                //		System.out.println("\tMSAccess database.mdb|accdb");
+                //                System.out.println("\tMSAccessUCanAccess database.mdb|accdb");
+                //                // System.out.println("\tODBC source [username password]");
+                //                System.out.println("\tDBML baseDir");
+                //
+                //                System.out.println("Available export modules:");
+                //                System.out.println("\tSIARD dir");
+                //                System.out.println(
+                //                  "\tSQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt");
+                //                System.out.println("\tPostgreSQLJDBC [port] hostName database username password encrypt");
+                //                System.out.println("\tMySQLJDBC hostName [port] database username password");
+                //                System.out.println("\tDB2JDBC hostname port database username password");
+                //                System.out.println("\tPhpMyAdmin hostName [port] database username password");
+                //                System.out.println("\tDBML baseDir");
+                //                //		System.out
+                //                //				.println("\tPostgreSQLFile sqlFile <- SQL file optimized for PostgreSQL");
+                //                //		System.out
+                //                //				.println("\tMySQLFile sqlFile <- SQL file optimized for MySQL");
+                //                //		System.out
+                //                //				.println("\tSQLServerFile sqlFile <- SQL file optimized for SQL Server");
+                //                //		System.out.println("\tGenericSQLFile sqlFile <- generic SQL file");
         }
 }

--- a/src/main/java/com/databasepreservation/Main.java
+++ b/src/main/java/com/databasepreservation/Main.java
@@ -64,45 +64,17 @@ public class Main {
         }
 
         public static int internal_main(String... args) {
+                final DatabaseImportModule importModule;
+                final DatabaseExportModule exportModule;
 
-                CLI cli = new CLI(new SQLServerJDBCModuleFactory());
+                CLI cli = new CLI(Arrays.asList(args), new SQLServerJDBCModuleFactory());
                 try {
-                        cli.parse(Arrays.asList(args));
+                        importModule = cli.getImportModule();
+                        exportModule = cli.getExportModule();
                 } catch (ParseException e) {
                         logger.fatal(e.getMessage());
                         cli.printHelp();
                         return EXIT_CODE_COMMAND_PARSE_ERROR;
-                }
-
-                List<String> importModuleArgs = new ArrayList<String>();
-                List<String> exportModuleArgs = new ArrayList<String>();
-
-                boolean parsingImportModule = false;
-                boolean parsingExportModule = false;
-
-                for (String arg : args) {
-                        if (arg.equals("-i")) {
-                                parsingImportModule = true;
-                                parsingExportModule = false;
-                        } else if (arg.equals("-o")) {
-                                parsingImportModule = false;
-                                parsingExportModule = true;
-                        } else if (parsingImportModule) {
-                                importModuleArgs.add(arg);
-                        } else if (parsingExportModule) {
-                                exportModuleArgs.add(arg);
-                        }
-                }
-
-                DatabaseImportModule importModule = null;
-                DatabaseExportModule exportModule = null;
-
-                if (importModuleArgs.size() > 0) {
-                        importModule = getImportModule(importModuleArgs);
-                }
-
-                if (exportModuleArgs.size() > 0) {
-                        exportModule = getExportModule(exportModuleArgs);
                 }
 
                 int exitStatus = EXIT_CODE_GENERIC_ERROR;

--- a/src/main/java/com/databasepreservation/Main.java
+++ b/src/main/java/com/databasepreservation/Main.java
@@ -47,7 +47,7 @@ public class Main {
                         importModule = cli.getImportModule();
                         exportModule = cli.getExportModule();
                 } catch (ParseException e) {
-                        logger.fatal(e.getMessage());
+                        System.out.println("error: " + e.getMessage());
                         cli.printHelp();
                         return EXIT_CODE_COMMAND_PARSE_ERROR;
                 }

--- a/src/main/java/com/databasepreservation/Main.java
+++ b/src/main/java/com/databasepreservation/Main.java
@@ -6,29 +6,14 @@ import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.exception.UnknownTypeException;
 import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
-import com.databasepreservation.modules.db2.in.DB2JDBCImportModule;
-import com.databasepreservation.modules.db2.out.DB2JDBCExportModule;
-import com.databasepreservation.modules.msAccess.in.MsAccessUCanAccessImportModule;
-import com.databasepreservation.modules.mySql.in.MySQLJDBCImportModule;
-import com.databasepreservation.modules.mySql.out.MySQLJDBCExportModule;
-import com.databasepreservation.modules.mySql.out.PhpMyAdminExportModule;
-import com.databasepreservation.modules.oracle.in.Oracle12cJDBCImportModule;
-import com.databasepreservation.modules.postgreSql.in.PostgreSQLJDBCImportModule;
-import com.databasepreservation.modules.postgreSql.out.PostgreSQLJDBCExportModule;
-import com.databasepreservation.modules.siard.in.input.SIARD1ImportModule;
-import com.databasepreservation.modules.siard.in.input.SIARD2ImportModule;
-import com.databasepreservation.modules.siard.out.output.SIARD1ExportModule;
-import com.databasepreservation.modules.siard.out.output.SIARD2ExportModule;
-import com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory;
-import com.databasepreservation.modules.sqlServer.in.SQLServerJDBCImportModule;
-import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
+import com.databasepreservation.modules.mySql.MySQLModuleFactory;
+import com.databasepreservation.modules.postgreSql.PostgreSQLModuleFactory;
+import com.databasepreservation.modules.siard.SIARD1ModuleFactory;
+import com.databasepreservation.modules.siard.SIARD2ModuleFactory;
 import org.apache.commons.cli.ParseException;
 import org.apache.log4j.Logger;
 
-import java.io.File;
-import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,7 +41,8 @@ public class Main {
                 final DatabaseImportModule importModule;
                 final DatabaseExportModule exportModule;
 
-                CLI cli = new CLI(Arrays.asList(args), new SQLServerJDBCModuleFactory());
+                CLI cli = new CLI(Arrays.asList(args), new MySQLModuleFactory(), new PostgreSQLModuleFactory(),
+                  new SIARD1ModuleFactory(), new SIARD2ModuleFactory());
                 try {
                         importModule = cli.getImportModule();
                         exportModule = cli.getExportModule();
@@ -67,343 +53,37 @@ public class Main {
                 }
 
                 int exitStatus = EXIT_CODE_GENERIC_ERROR;
-                if (importModule != null && exportModule != null) {
-                        try {
-                                long startTime = System.currentTimeMillis();
-                                logger.info("Translating database: " + importModule.getClass().getSimpleName() + " to "
-                                  + exportModule.getClass().getSimpleName());
-                                importModule.getDatabase(exportModule);
-                                long duration = System.currentTimeMillis() - startTime;
-                                logger.info("Done in " + (duration / 60000) + "m " + (duration % 60000 / 1000) + "s");
-                                exitStatus = EXIT_CODE_OK;
-                        } catch (ModuleException e) {
-                                if (e.getCause() != null && e.getCause() instanceof ClassNotFoundException && e
-                                  .getCause().getMessage().equals("sun.jdbc.odbc.JdbcOdbcDriver")) {
-                                        logger.error("Could not find the Java ODBC driver, "
-                                            + "please run this program under Windows to use the JDBC-ODBC bridge.",
-                                          e.getCause());
-                                } else if (e.getModuleErrors() != null) {
-                                        for (Map.Entry<String, Throwable> entry : e.getModuleErrors().entrySet()) {
-                                                logger.error(entry.getKey(), entry.getValue());
-                                        }
-                                } else {
-                                        logger.error("Error while importing/exporting", e);
-                                }
-                        } catch (UnknownTypeException e) {
-                                logger.error("Error while importing/exporting", e);
-                        } catch (InvalidDataException e) {
-                                logger.error("Error while importing/exporting", e);
-                        } catch (Exception e) {
-                                logger.error("Unexpected exception", e);
-                        }
 
-                } else {
-                        printHelp();
-                        exitStatus = EXIT_CODE_COMMAND_PARSE_ERROR;
+                try {
+                        long startTime = System.currentTimeMillis();
+                        logger.info(
+                          "Translating database: " + importModule.getClass().getSimpleName() + " to " + exportModule
+                            .getClass().getSimpleName());
+                        importModule.getDatabase(exportModule);
+                        long duration = System.currentTimeMillis() - startTime;
+                        logger.info("Done in " + (duration / 60000) + "m " + (duration % 60000 / 1000) + "s");
+                        exitStatus = EXIT_CODE_OK;
+                } catch (ModuleException e) {
+                        if (e.getCause() != null && e.getCause() instanceof ClassNotFoundException && e.getCause()
+                          .getMessage().equals("sun.jdbc.odbc.JdbcOdbcDriver")) {
+                                logger.error("Could not find the Java ODBC driver, "
+                                    + "please run this program under Windows to use the JDBC-ODBC bridge.",
+                                  e.getCause());
+                        } else if (e.getModuleErrors() != null) {
+                                for (Map.Entry<String, Throwable> entry : e.getModuleErrors().entrySet()) {
+                                        logger.error(entry.getKey(), entry.getValue());
+                                }
+                        } else {
+                                logger.error("Error while importing/exporting", e);
+                        }
+                } catch (UnknownTypeException e) {
+                        logger.error("Error while importing/exporting", e);
+                } catch (InvalidDataException e) {
+                        logger.error("Error while importing/exporting", e);
+                } catch (Exception e) {
+                        logger.error("Unexpected exception", e);
                 }
+
                 return exitStatus;
-        }
-
-        private static DatabaseImportModule getImportModule(List<String> importModuleArgs) {
-                DatabaseImportModule importModule = null;
-                if (importModuleArgs.get(0).equalsIgnoreCase("SQLServerJDBC")) {
-                        if (importModuleArgs.size() == 7) {
-                                importModule = new SQLServerJDBCImportModule(importModuleArgs.get(1),
-                                  importModuleArgs.get(2), importModuleArgs.get(3), importModuleArgs.get(4),
-                                  importModuleArgs.get(5).equals("true"), importModuleArgs.get(6).equals("true"));
-                        } else if (importModuleArgs.size() == 8) {
-                                try {
-                                        importModule = new SQLServerJDBCImportModule(importModuleArgs.get(1),
-                                          Integer.valueOf(importModuleArgs.get(2)).intValue(), importModuleArgs.get(3),
-                                          importModuleArgs.get(4), importModuleArgs.get(5),
-                                          importModuleArgs.get(6).equals("true"),
-                                          importModuleArgs.get(7).equals("true"));
-                                } catch (NumberFormatException e) {
-                                        importModule = new SQLServerJDBCImportModule(importModuleArgs.get(1),
-                                          importModuleArgs.get(2), importModuleArgs.get(3), importModuleArgs.get(4),
-                                          importModuleArgs.get(5), importModuleArgs.get(6).equals("true"),
-                                          importModuleArgs.get(7).equals("true"));
-                                }
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "SQLServerJDBC import module: " + importModuleArgs
-                                    .size());
-                        }
-                } else if (importModuleArgs.get(0).equalsIgnoreCase("PostgreSQLJDBC")) {
-                        if (importModuleArgs.size() == 6) {
-                                importModule = new PostgreSQLJDBCImportModule(importModuleArgs.get(1),
-                                  importModuleArgs.get(2), importModuleArgs.get(3), importModuleArgs.get(4),
-                                  importModuleArgs.get(5).equals("true"));
-                        } else if (importModuleArgs.size() == 7) {
-                                importModule = new PostgreSQLJDBCImportModule(importModuleArgs.get(1),
-                                  Integer.valueOf(importModuleArgs.get(2)).intValue(), importModuleArgs.get(3),
-                                  importModuleArgs.get(4), importModuleArgs.get(5),
-                                  importModuleArgs.get(6).equals("true"));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "PostgreSQLJDBC import module: " + importModuleArgs
-                                    .size());
-                        }
-                } else if (importModuleArgs.get(0).equalsIgnoreCase("DB2JDBC")) {
-                        if (importModuleArgs.size() == 6) {
-                                importModule = new DB2JDBCImportModule(importModuleArgs.get(1),
-                                  Integer.valueOf(importModuleArgs.get(2)), importModuleArgs.get(3),
-                                  importModuleArgs.get(4), importModuleArgs.get(5));
-                        } else {
-                                logger
-                                  .error("Wrong argument number for DB2JDBC import module: " + importModuleArgs.size());
-                        }
-                } else if (importModuleArgs.get(0).equalsIgnoreCase("MySQLJDBC")) {
-                        if (importModuleArgs.size() == 5) {
-                                importModule = new MySQLJDBCImportModule(importModuleArgs.get(1),
-                                  importModuleArgs.get(2), importModuleArgs.get(3), importModuleArgs.get(4));
-                        } else if (importModuleArgs.size() == 6) {
-                                importModule = new MySQLJDBCImportModule(importModuleArgs.get(1),
-                                  Integer.valueOf(importModuleArgs.get(2)).intValue(), importModuleArgs.get(3),
-                                  importModuleArgs.get(4), importModuleArgs.get(5));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "MySQLJDBC import module: " + importModuleArgs.size());
-                        }
-                } else if (importModuleArgs.get(0).equalsIgnoreCase("SIARD1")) {
-                        if (importModuleArgs.size() == 2) {
-                                importModule = new SIARD1ImportModule(Paths.get(importModuleArgs.get(1)))
-                                  .getDatabaseImportModule();
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "SIARD1 import module: " + importModuleArgs.size());
-                        }
-                } else if (importModuleArgs.get(0).equalsIgnoreCase("SIARD2")) {
-                        if (importModuleArgs.size() == 2) {
-                                importModule = new SIARD2ImportModule(Paths.get(importModuleArgs.get(1)))
-                                  .getDatabaseImportModule();
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "SIARD2 import module: " + importModuleArgs.size());
-                        }
-                } else if (importModuleArgs.get(0).equalsIgnoreCase("Oracle12cJDBC")) {
-                        if (importModuleArgs.size() == 6) {
-                                importModule = new Oracle12cJDBCImportModule(importModuleArgs.get(1),
-                                  Integer.valueOf(importModuleArgs.get(2)).intValue(), importModuleArgs.get(3),
-                                  importModuleArgs.get(4), importModuleArgs.get(5));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "Oracle12c import module: " + importModuleArgs.size());
-                        }
-                        //		} else if (importModuleArgs.get(0).equals("MSAccess")) {
-                        //			if (importModuleArgs.size() == 2) {
-                        //				importModule = new MsAccessImportModule(new File(
-                        //						importModuleArgs.get(1)));
-                        //			} else {
-                        //				logger.error("Wrong argument number for "
-                        //						+ "MSAccess import module: " + importModuleArgs.size());
-                        //			}
-                } else if (importModuleArgs.get(0).equals("MSAccessUCanAccess")) {
-                        if (importModuleArgs.size() == 2) {
-                                importModule = new MsAccessUCanAccessImportModule(new File(importModuleArgs.get(1)));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "MSAccessExp import module: " + importModuleArgs
-                                    .size());
-                        }
-                        //		} else if (importModuleArgs.get(0).equals("ODBC")) {
-                        //			if (importModuleArgs.size() == 2) {
-                        //				importModule = new ODBCImportModule(importModuleArgs.get(1));
-                        //			} else if (importModuleArgs.size() == 4) {
-                        //				importModule = new ODBCImportModule(importModuleArgs.get(1),
-                        //						importModuleArgs.get(2), importModuleArgs.get(3));
-                        //			} else {
-                        //				logger.error("Wrong argument number for "
-                        //						+ "ODBC import module: " + importModuleArgs.size());
-                        //			}
-                } else {
-                        logger.error("Unrecognized import module: " + importModuleArgs.get(0));
-                }
-                return importModule;
-        }
-
-        private static DatabaseExportModule getExportModule(List<String> exportModuleArgs) {
-                DatabaseExportModule exportModule = null;
-                if (exportModuleArgs.get(0).equalsIgnoreCase("SIARD1")) {
-                        if (exportModuleArgs.size() == 3) {
-                                exportModule = new SIARD1ExportModule(Paths.get(exportModuleArgs.get(1)),
-                                  exportModuleArgs.get(2).equals("compress")).getDatabaseHandler();
-                        } else {
-                                logger
-                                  .error("Wrong argument number for SIARD1 export module: " + exportModuleArgs.size());
-                        }
-                } else if (exportModuleArgs.get(0).equalsIgnoreCase("SIARD2")) {
-                        if (exportModuleArgs.size() == 3) {
-                                exportModule = new SIARD2ExportModule(Paths.get(exportModuleArgs.get(1)),
-                                  exportModuleArgs.get(2).equals("compress")).getDatabaseHandler();
-                        } else {
-                                logger
-                                  .error("Wrong argument number for SIARD2 export module: " + exportModuleArgs.size());
-                        }
-                } else if (exportModuleArgs.get(0).equalsIgnoreCase("DB2JDBC")) {
-                        if (exportModuleArgs.size() == 6) {
-                                exportModule = new DB2JDBCExportModule(exportModuleArgs.get(1),
-                                  Integer.valueOf(exportModuleArgs.get(2)), exportModuleArgs.get(3),
-                                  exportModuleArgs.get(4), exportModuleArgs.get(5));
-                        } else {
-                                logger
-                                  .error("Wrong argument number for DB2JDBC export module: " + exportModuleArgs.size());
-                        }
-                } else if (exportModuleArgs.get(0).equalsIgnoreCase("PostgreSQLJDBC")) {
-                        if (exportModuleArgs.size() == 6) {
-                                exportModule = new PostgreSQLJDBCExportModule(exportModuleArgs.get(1),
-                                  exportModuleArgs.get(2), exportModuleArgs.get(3), exportModuleArgs.get(4),
-                                  exportModuleArgs.get(5).equals("true"));
-                        } else if (exportModuleArgs.size() == 7) {
-                                exportModule = new PostgreSQLJDBCExportModule(exportModuleArgs.get(1),
-                                  Integer.valueOf(exportModuleArgs.get(2)).intValue(), exportModuleArgs.get(3),
-                                  exportModuleArgs.get(4), exportModuleArgs.get(5),
-                                  exportModuleArgs.get(6).equals("true"));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "PostgreSQLJDBC export module: " + exportModuleArgs
-                                    .size());
-                        }
-                        //		} else if (exportModuleArgs.get(0).equals("PostgreSQLFile")) {
-                        //			if (exportModuleArgs.size() == 2) {
-                        //				try {
-                        //					exportModule = new SQLFileExportModule(new File(
-                        //							exportModuleArgs.get(1)), new PostgreSQLHelper());
-                        //				} catch (ModuleException e) {
-                        //					logger.error("Error creating PostgreSQLFile export module", e);
-                        //				}
-                        //			} else {
-                        //				logger.error("Wrong argument number for "
-                        //						+ "PostgreSQLFile export module: " + exportModuleArgs.size());
-                        //			}
-                } else if (exportModuleArgs.get(0).equalsIgnoreCase("MySQLJDBC")) {
-                        if (exportModuleArgs.size() == 5) {
-                                exportModule = new MySQLJDBCExportModule(exportModuleArgs.get(1),
-                                  exportModuleArgs.get(2), exportModuleArgs.get(3), exportModuleArgs.get(4));
-                        } else if (exportModuleArgs.size() == 6) {
-                                exportModule = new MySQLJDBCExportModule(exportModuleArgs.get(1),
-                                  Integer.valueOf(exportModuleArgs.get(2)).intValue(), exportModuleArgs.get(3),
-                                  exportModuleArgs.get(4), exportModuleArgs.get(5));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "MySQLJDBC export module: " + exportModuleArgs.size());
-                        }
-                        //		} else if (exportModuleArgs.get(0).equals("MySQLFile")) {
-                        //			if (exportModuleArgs.size() == 2) {
-                        //				try {
-                        //					exportModule = new SQLFileExportModule(new File(
-                        //							exportModuleArgs.get(1)), new MySQLHelper());
-                        //				} catch (ModuleException e) {
-                        //					logger.error("Error creating MySQLFile export module", e);
-                        //				}
-                        //
-                        //			} else {
-                        //				logger.error("Wrong argument number for "
-                        //						+ "MySQLFile export module: " + exportModuleArgs.size());
-                        //			}
-                } else if (exportModuleArgs.get(0).equals("PhpMyAdmin")) {
-                        if (exportModuleArgs.size() == 5) {
-                                exportModule = new PhpMyAdminExportModule(exportModuleArgs.get(1),
-                                  exportModuleArgs.get(2), exportModuleArgs.get(3), exportModuleArgs.get(4));
-                        } else if (exportModuleArgs.size() == 6) {
-                                exportModule = new PhpMyAdminExportModule(exportModuleArgs.get(1),
-                                  Integer.valueOf(exportModuleArgs.get(2)).intValue(), exportModuleArgs.get(3),
-                                  exportModuleArgs.get(4), exportModuleArgs.get(5));
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "PhpMyAdmin export module: " + exportModuleArgs
-                                    .size());
-                        }
-                } else if (exportModuleArgs.get(0).equalsIgnoreCase("SQLServerJDBC")) {
-                        if (exportModuleArgs.size() == 7) {
-                                exportModule = new SQLServerJDBCExportModule(exportModuleArgs.get(1),
-                                  exportModuleArgs.get(2), exportModuleArgs.get(3), exportModuleArgs.get(4),
-                                  exportModuleArgs.get(5).equals("true"), exportModuleArgs.get(6).equals("true"));
-                        } else if (exportModuleArgs.size() == 8) {
-                                try {
-                                        exportModule = new SQLServerJDBCExportModule(exportModuleArgs.get(1),
-                                          Integer.valueOf(exportModuleArgs.get(2)).intValue(), exportModuleArgs.get(3),
-                                          exportModuleArgs.get(4), exportModuleArgs.get(5),
-                                          exportModuleArgs.get(6).equals("true"),
-                                          exportModuleArgs.get(7).equals("true"));
-                                } catch (NumberFormatException e) {
-                                        exportModule = new SQLServerJDBCExportModule(exportModuleArgs.get(1),
-                                          exportModuleArgs.get(2), exportModuleArgs.get(3), exportModuleArgs.get(4),
-                                          exportModuleArgs.get(5), exportModuleArgs.get(6).equals("true"),
-                                          exportModuleArgs.get(7).equals("true"));
-                                }
-                        } else {
-                                logger.error(
-                                  "Wrong argument number for " + "SQLServerJDBC import module: " + exportModuleArgs
-                                    .size());
-                        }
-                        //		} else if (exportModuleArgs.get(0).equals("SQLServerFile")) {
-                        //			if (exportModuleArgs.size() == 2) {
-                        //				try {
-                        //					exportModule = new SQLFileExportModule(new File(
-                        //							exportModuleArgs.get(1)), new SQLServerHelper());
-                        //				} catch (ModuleException e) {
-                        //					logger.error("Error creating SQLServerFile export module", e);
-                        //				}
-                        //
-                        //			} else {
-                        //				logger.error("Wrong argument number for "
-                        //						+ "SQLServerFile export module: "
-                        //						+ exportModuleArgs.size());
-                        //			}
-                        //		} else if (exportModuleArgs.get(0).equals("GenericSQLFile")) {
-                        //			if (exportModuleArgs.size() == 2) {
-                        //				try {
-                        //					exportModule = new SQLFileExportModule(new File(
-                        //							exportModuleArgs.get(1)), new SQLHelper());
-                        //				} catch (ModuleException e) {
-                        //					logger.error("Error creating GenericSQLFile export module", e);
-                        //				}
-                        //
-                        //			} else {
-                        //				logger.error("Wrong argument number for "
-                        //						+ "GenericSQLFile export module: "
-                        //						+ exportModuleArgs.size());
-                        //			}
-                } else {
-                        logger.error("Unrecognized export module: " + exportModuleArgs.get(0));
-                }
-                return exportModule;
-        }
-
-        private static void printHelp() {
-                //                new HelpFormatter().printHelp(80, "dbptk", "\nModule Options:", commandLineOptions, null, true);
-
-                //                System.out.println("Synopsys: java -jar " + NAME + ".jar" + " -i IMPORT_MODULE [options...]"
-                //                  + " -o EXPORT_MODULE [options...]");
-                //                System.out.println("Available import modules:");
-                //                System.out.println("\tSIARD dir compress|store");
-                //                System.out.println(
-                //                  "\tSQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt");
-                //                System.out.println("\tPostgreSQLJDBC hostName [port] database username password encrypt");
-                //                System.out.println("\tMySQLJDBC hostName [port] database username password");
-                //                System.out.println("\tDB2JDBC hostname port database username password");
-                //                System.out.println("\tOracle12c hostName port database username password");
-                //                //		System.out.println("\tMSAccess database.mdb|accdb");
-                //                System.out.println("\tMSAccessUCanAccess database.mdb|accdb");
-                //                // System.out.println("\tODBC source [username password]");
-                //                System.out.println("\tDBML baseDir");
-                //
-                //                System.out.println("Available export modules:");
-                //                System.out.println("\tSIARD dir");
-                //                System.out.println(
-                //                  "\tSQLServerJDBC serverName [port|instance] database username password useIntegratedSecurity encrypt");
-                //                System.out.println("\tPostgreSQLJDBC [port] hostName database username password encrypt");
-                //                System.out.println("\tMySQLJDBC hostName [port] database username password");
-                //                System.out.println("\tDB2JDBC hostname port database username password");
-                //                System.out.println("\tPhpMyAdmin hostName [port] database username password");
-                //                System.out.println("\tDBML baseDir");
-                //                //		System.out
-                //                //				.println("\tPostgreSQLFile sqlFile <- SQL file optimized for PostgreSQL");
-                //                //		System.out
-                //                //				.println("\tMySQLFile sqlFile <- SQL file optimized for MySQL");
-                //                //		System.out
-                //                //				.println("\tSQLServerFile sqlFile <- SQL file optimized for SQL Server");
-                //                //		System.out.println("\tGenericSQLFile sqlFile <- generic SQL file");
         }
 }

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -258,19 +258,83 @@ public class CLI {
                 Collections.sort(modulesList, new DatabaseModuleFactoryNameComparator());
                 int textOffset = 0;
 
-                out.append("Available import modules: -i <module>, --import=module\n");
+                out.append("## Available import modules: -i <module>, --import=module\n");
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesImportModules()) {
-                                //TODO: describe arguments
+                                try {
+                                        out.append(printModuleHelp("Import module: " + factory.getModuleName(), factory.getImportModuleParameters()));
+                                } catch (OperationNotSupportedException e) {
+                                        //this should never happen
+                                }
                         }
                 }
 
-                out.append("Available export modules: -e <module>, --export=module\n");
+                out.append("\n## Available export modules: -e <module>, --export=module\n");
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesExportModules()) {
-                                //TODO: describe arguments
+                                try {
+                                        out.append(printModuleHelp("Export module: " + factory.getModuleName(), factory.getExportModuleParameters()));
+                                } catch (OperationNotSupportedException e) {
+                                        //this should never happen
+                                }
                         }
                 }
+
+                printStream.append(out).flush();
+        }
+
+        private String printModuleHelp(String moduleDesignation, Parameters moduleParameters){
+                StringBuilder out = new StringBuilder();
+
+                String space = "    ";
+
+                out.append("\n").append(moduleDesignation);
+
+                for (Parameter parameter : moduleParameters.getParameters()) {
+                        out.append(printParameterHelp(space, parameter));
+                }
+
+                for (ParameterGroup parameterGroup : moduleParameters.getGroups()) {
+                        for (Parameter parameter : parameterGroup.getParameters()) {
+                                out.append(printParameterHelp(space, parameter));
+                        }
+                }
+                out.append("\n");
+
+                return out.toString();
+        }
+
+        private String printParameterHelp(String space, Parameter parameter){
+                StringBuilder out = new StringBuilder();
+
+                out.append("\n").append(space);
+
+                if(StringUtils.isNotBlank(parameter.shortName())){
+                        out.append("-").append(parameter.shortName()).append(", ");
+                }
+
+                out.append("--").append(parameter.longName());
+
+                if(parameter.hasArgument()){
+                        out.append("=");
+                        if(parameter.isOptionalArgument()){
+                                out.append("[");
+                        }
+                        out.append("value");
+                        if(parameter.isOptionalArgument()){
+                                out.append("]");
+                        }
+                }
+
+                out.append(space);
+                if(parameter.required()){
+                        out.append("(required) ");
+                }else{
+                        out.append("(optional) ");
+                }
+                out.append(parameter.description());
+
+                return out.toString();
         }
 
         private static class DatabaseModuleFactoryNameComparator implements Comparator<DatabaseModuleFactory> {

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -36,41 +36,8 @@ public class CLI {
         private DatabaseImportModule importModule;
         private DatabaseExportModule exportModule;
 
-        //        private static Class<? extends DatabaseModuleFactory>[] getModuleFactoriesFromConfiguration(){
-        //                InputStream cliPropertiesStream = CLI.class.getResourceAsStream("/config/cli.properties");
-        //                Properties cliProperties = new Properties();
-        //                try {
-        //                        cliProperties.load(cliPropertiesStream);
-        //                } catch (IOException e) {
-        //                        e.printStackTrace();
-        //                }
-        //                String module = (String)cliProperties.get("modules");
-        //
-        //                Class<?> aClass = null;
-        //                try {
-        //                        aClass = Class.forName(module);
-        //                } catch (ClassNotFoundException e) {
-        //                        e.printStackTrace();
-        //                }
-        //
-        //                Class<? extends DatabaseModuleFactory> aClass1 = null;
-        //                if(aClass.isAssignableFrom(DatabaseModuleFactory.class)){
-        //                        aClass1 = aClass.asSubclass(DatabaseModuleFactory.class);
-        //                }
-        //
-        //                ArrayList<Class<? extends DatabaseModuleFactory>> list = new ArrayList<Class<? extends DatabaseModuleFactory>>();
-        //                list.add(aClass1);
-        //
-        //                //return list.toArray(new Class<? extends DatabaseModuleFactory>[]{});
-        //                return null;
-        //        }
-        //
-        //        public CLI(){
-        //                this(getModuleFactoriesFromConfiguration());
-        //        }
-
         public CLI(List<String> commandLineArguments,
-          Class<? extends DatabaseModuleFactory>... databaseModuleFactories) {
+          List<Class<? extends DatabaseModuleFactory>> databaseModuleFactories) {
                 factories = new ArrayList<DatabaseModuleFactory>();
                 this.commandLineArguments = commandLineArguments;
                 try {
@@ -294,14 +261,14 @@ public class CLI {
                 out.append("Available import modules: -i <module>, --import=module\n");
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesImportModules()) {
-
+                                //TODO: describe arguments
                         }
                 }
 
                 out.append("Available export modules: -e <module>, --export=module\n");
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesExportModules()) {
-
+                                //TODO: describe arguments
                         }
                 }
         }

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import javax.naming.OperationNotSupportedException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +26,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Properties;
 
 /**
  * Handles command line interface
@@ -251,8 +254,10 @@ public class CLI {
         private void printHelp(PrintStream printStream) {
                 StringBuilder out = new StringBuilder();
 
-                out.append(
-                  "Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
+                out.append("Database Preservation Toolkit, v")
+                  .append(getApplicationVersion())
+                  .append("\nMore info: http://www.database-preservation.com").append("\n")
+                  .append("Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
 
                 ArrayList<DatabaseModuleFactory> modulesList = new ArrayList<DatabaseModuleFactory>(factories);
                 Collections.sort(modulesList, new DatabaseModuleFactoryNameComparator());
@@ -335,6 +340,20 @@ public class CLI {
                 out.append(parameter.description());
 
                 return out.toString();
+        }
+
+        public static String getApplicationVersion(){
+                InputStream resourceAsStream = CLI.class
+                  .getResourceAsStream("/META-INF/maven/pt.keep/db-preservation-toolkit/pom.properties");
+                Properties properties = new Properties();
+
+                try {
+                        properties.load(resourceAsStream);
+                } catch (IOException e) {
+                        // ignore the error
+                }
+
+                return properties.getProperty("version", "?");
         }
 
         private static class DatabaseModuleFactoryNameComparator implements Comparator<DatabaseModuleFactory> {

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -6,7 +6,6 @@ import com.databasepreservation.modules.DatabaseModuleFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
@@ -241,7 +240,7 @@ public class CLI {
                 options.addOption(importOption);
                 options.addOption(exportOption);
 
-                new HelpFormatter().printHelp(80, "dbptk", "\nModule Options:", options, null, true);
+                //new HelpFormatter().printHelp(80, "dbptk", "\nModule Options:", options, null, true);
 
                 // parse the command line arguments with those options
                 try {

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -15,6 +15,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
+import javax.naming.OperationNotSupportedException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -115,14 +116,19 @@ public class CLI {
          */
         private void parse(List<String> args) throws ParseException {
                 DatabaseModuleFactoriesPair databaseModuleFactoriesPair = getModuleFactories(args);
-                DatabaseModuleFactoriesArguments databaseModuleFactoriesArguments = getModuleArguments(
-                  databaseModuleFactoriesPair, args);
 
-                // set import and export modules
-                importModule = databaseModuleFactoriesPair.getImportModuleFactory()
-                  .buildImportModule(databaseModuleFactoriesArguments.getImportModuleArguments());
-                exportModule = databaseModuleFactoriesPair.getExportModuleFactory()
-                  .buildExportModule(databaseModuleFactoriesArguments.getExportModuleArguments());
+                try {
+                        DatabaseModuleFactoriesArguments databaseModuleFactoriesArguments = getModuleArguments(
+                          databaseModuleFactoriesPair, args);
+
+                        // set import and export modules
+                        importModule = databaseModuleFactoriesPair.getImportModuleFactory()
+                          .buildImportModule(databaseModuleFactoriesArguments.getImportModuleArguments());
+                        exportModule = databaseModuleFactoriesPair.getExportModuleFactory()
+                          .buildExportModule(databaseModuleFactoriesArguments.getExportModuleArguments());
+                } catch (OperationNotSupportedException e) {
+                        throw new ParseException("Module does not support the requested mode.");
+                }
         }
 
         /**
@@ -192,7 +198,7 @@ public class CLI {
          * @throws ParseException If the arguments could not be parsed or are invalid
          */
         private DatabaseModuleFactoriesArguments getModuleArguments(DatabaseModuleFactoriesPair factoriesPair,
-          List<String> args) throws ParseException {
+          List<String> args) throws ParseException, OperationNotSupportedException {
                 DatabaseModuleFactory importModuleFactory = factoriesPair.getImportModuleFactory();
                 DatabaseModuleFactory exportModuleFactory = factoriesPair.getExportModuleFactory();
 

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -257,7 +257,8 @@ public class CLI {
                 out.append("Database Preservation Toolkit, v")
                   .append(getApplicationVersion())
                   .append("\nMore info: http://www.database-preservation.com").append("\n")
-                  .append("Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
+                  .append(
+                    "Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
 
                 ArrayList<DatabaseModuleFactory> modulesList = new ArrayList<DatabaseModuleFactory>(factories);
                 Collections.sort(modulesList, new DatabaseModuleFactoryNameComparator());
@@ -267,7 +268,7 @@ public class CLI {
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesImportModules()) {
                                 try {
-                                        out.append(printModuleHelp("Import module: " + factory.getModuleName(), factory.getImportModuleParameters()));
+                                        out.append(printModuleHelp("Import module: " + factory.getModuleName(), "i", factory.getImportModuleParameters()));
                                 } catch (OperationNotSupportedException e) {
                                         //this should never happen
                                 }
@@ -278,7 +279,7 @@ public class CLI {
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesExportModules()) {
                                 try {
-                                        out.append(printModuleHelp("Export module: " + factory.getModuleName(), factory.getExportModuleParameters()));
+                                        out.append(printModuleHelp("Export module: " + factory.getModuleName(), "e", factory.getExportModuleParameters()));
                                 } catch (OperationNotSupportedException e) {
                                         //this should never happen
                                 }
@@ -288,7 +289,7 @@ public class CLI {
                 printStream.append(out).flush();
         }
 
-        private String printModuleHelp(String moduleDesignation, Parameters moduleParameters){
+        private String printModuleHelp(String moduleDesignation, String parameterPrefix, Parameters moduleParameters){
                 StringBuilder out = new StringBuilder();
 
                 String space = "    ";
@@ -296,12 +297,12 @@ public class CLI {
                 out.append("\n").append(moduleDesignation);
 
                 for (Parameter parameter : moduleParameters.getParameters()) {
-                        out.append(printParameterHelp(space, parameter));
+                        out.append(printParameterHelp(space, parameterPrefix, parameter));
                 }
 
                 for (ParameterGroup parameterGroup : moduleParameters.getGroups()) {
                         for (Parameter parameter : parameterGroup.getParameters()) {
-                                out.append(printParameterHelp(space, parameter));
+                                out.append(printParameterHelp(space, parameterPrefix, parameter));
                         }
                 }
                 out.append("\n");
@@ -309,16 +310,16 @@ public class CLI {
                 return out.toString();
         }
 
-        private String printParameterHelp(String space, Parameter parameter){
+        private String printParameterHelp(String space, String prefix, Parameter parameter){
                 StringBuilder out = new StringBuilder();
 
                 out.append("\n").append(space);
 
                 if(StringUtils.isNotBlank(parameter.shortName())){
-                        out.append("-").append(parameter.shortName()).append(", ");
+                        out.append("-").append(prefix).append(parameter.shortName()).append(", ");
                 }
 
-                out.append("--").append(parameter.longName());
+                out.append("--").append(prefix).append(parameter.longName());
 
                 if(parameter.hasArgument()){
                         out.append("=");

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -1,19 +1,27 @@
 package com.databasepreservation.cli;
 
-import com.databasepreservation.Main;
 import com.databasepreservation.modules.DatabaseModuleFactory;
-import com.sun.tools.javac.util.List;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.MissingArgumentException;
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Handles command line interface
@@ -21,52 +29,47 @@ import java.util.Properties;
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class CLI {
-        private final Map<Class<? extends DatabaseModuleFactory>, ModuleInfo> modulesInfo;
+        private final ArrayList<DatabaseModuleFactory> factories;
 
-        private static Class<? extends DatabaseModuleFactory>[] getModuleFactoriesFromConfiguration(){
-                InputStream cliPropertiesStream = CLI.class.getResourceAsStream("/config/cli.properties");
-                Properties cliProperties = new Properties();
+        //        private static Class<? extends DatabaseModuleFactory>[] getModuleFactoriesFromConfiguration(){
+        //                InputStream cliPropertiesStream = CLI.class.getResourceAsStream("/config/cli.properties");
+        //                Properties cliProperties = new Properties();
+        //                try {
+        //                        cliProperties.load(cliPropertiesStream);
+        //                } catch (IOException e) {
+        //                        e.printStackTrace();
+        //                }
+        //                String module = (String)cliProperties.get("modules");
+        //
+        //                Class<?> aClass = null;
+        //                try {
+        //                        aClass = Class.forName(module);
+        //                } catch (ClassNotFoundException e) {
+        //                        e.printStackTrace();
+        //                }
+        //
+        //                Class<? extends DatabaseModuleFactory> aClass1 = null;
+        //                if(aClass.isAssignableFrom(DatabaseModuleFactory.class)){
+        //                        aClass1 = aClass.asSubclass(DatabaseModuleFactory.class);
+        //                }
+        //
+        //                ArrayList<Class<? extends DatabaseModuleFactory>> list = new ArrayList<Class<? extends DatabaseModuleFactory>>();
+        //                list.add(aClass1);
+        //
+        //                //return list.toArray(new Class<? extends DatabaseModuleFactory>[]{});
+        //                return null;
+        //        }
+        //
+        //        public CLI(){
+        //                this(getModuleFactoriesFromConfiguration());
+        //        }
+
+        public CLI(Class<? extends DatabaseModuleFactory>... databaseModuleFactories) {
+                factories = new ArrayList<DatabaseModuleFactory>();
+
                 try {
-                        cliProperties.load(cliPropertiesStream);
-                } catch (IOException e) {
-                        e.printStackTrace();
-                }
-                String module = (String)cliProperties.get("modules");
-
-                Class<?> aClass = null;
-                try {
-                        aClass = Class.forName(module);
-                } catch (ClassNotFoundException e) {
-                        e.printStackTrace();
-                }
-
-                Class<? extends DatabaseModuleFactory> aClass1 = null;
-                if(aClass.isAssignableFrom(DatabaseModuleFactory.class)){
-                        aClass1 = aClass.asSubclass(DatabaseModuleFactory.class);
-                }
-
-                ArrayList<Class<? extends DatabaseModuleFactory>> list = new ArrayList<Class<? extends DatabaseModuleFactory>>();
-                list.add(aClass1);
-
-                //return list.toArray(new Class<? extends DatabaseModuleFactory>[]{});
-                return null;
-        }
-
-        public CLI(){
-                this(getModuleFactoriesFromConfiguration());
-        }
-
-        public CLI(Class<? extends DatabaseModuleFactory>... databaseModuleFactory) {
-                modulesInfo = new HashMap<Class<? extends DatabaseModuleFactory>, ModuleInfo>();
-
-                try {
-                        for (Class<? extends DatabaseModuleFactory> factoryClass : databaseModuleFactory) {
-                                DatabaseModuleFactory factory = factoryClass.newInstance();
-
-                                modulesInfo.put(factoryClass,
-                                  new ModuleInfo(factory.getModuleName(), factory.producesImportModules(),
-                                    factory.getImportModuleParameters(), factory.producesExportModules(),
-                                    factory.getExportModuleParameters()));
+                        for (Class<? extends DatabaseModuleFactory> factoryClass : databaseModuleFactories) {
+                                factories.add(factoryClass.newInstance());
                         }
                 } catch (InstantiationException e) {
                         e.printStackTrace();
@@ -75,76 +78,152 @@ public class CLI {
                 }
         }
 
-        public void parse(String... args) {
-                // verificar (em args) quais são os módulos de import e export
-                // se não houver exactamente 1 export e 1 import, mostra o texto de ajuda
-                // só fazer a transformação de Parameter para Option nesses módulos (para não ter conflitos)
-                //
-
+        public CLI(DatabaseModuleFactory... databaseModuleFactories) {
+                factories = new ArrayList<DatabaseModuleFactory>(Arrays.asList(databaseModuleFactories));
         }
 
-        public void printHelp(PrintStream printStream){
+        public void parse(List<String> args) throws ParseException {
+                // check if args contains exactly one import and one export module
+                String importModuleName = null;
+                String exportModuleName = null;
+                int importModulesFound = 0;
+                int exportModulesFound = 0;
+                Iterator<String> argsIterator = args.iterator();
+                try {
+                        while (argsIterator.hasNext()) {
+                                String arg = argsIterator.next();
+                                if (arg.equals("-i") || arg.equals("--import")) {
+                                        importModuleName = argsIterator.next();
+                                        importModulesFound++;
+                                } else if (arg.equals("-e") || arg.equals("--export")) {
+                                        exportModuleName = argsIterator.next();
+                                        exportModulesFound++;
+                                } else if (StringUtils.startsWith(arg, "--import=")) {
+                                        importModuleName = arg.substring(9); // 9 is the size of the string "--import="
+                                        importModulesFound++;
+                                } else if (StringUtils.startsWith(arg, "--export=")) {
+                                        exportModuleName = arg.substring(9); // 9 is the size of the string "--export="
+                                        exportModulesFound++;
+                                }
+                        }
+                } catch (NoSuchElementException e) {
+                        throw new ParseException("Missing module name.");
+                }
+                if (importModulesFound != 1 || exportModulesFound != 1) {
+                        throw new ParseException("Exactly one import module and one export module must be specified.");
+                }
+
+                // check if both module names correspond to real module names
+                DatabaseModuleFactory importModuleFactory = null;
+                DatabaseModuleFactory exportModuleFactory = null;
+                for (DatabaseModuleFactory factory : factories) {
+                        String moduleName = factory.getModuleName();
+                        if (moduleName.equals(importModuleName) && factory.producesImportModules()) {
+                                importModuleFactory = factory;
+                        }
+                        if (moduleName.equals(exportModuleName) && factory.producesExportModules()) {
+                                exportModuleFactory = factory;
+                        }
+                }
+                if (importModuleFactory == null) {
+                        throw new ParseException("Invalid import module.");
+                } else if (exportModuleFactory == null) {
+                        throw new ParseException("Invalid export module.");
+                }
+
+                // get appropriate command line options
+                CommandLineParser commandLineParser = new DefaultParser();
+                CommandLine commandLine;
+                Options options = new Options();
+
+                HashMap<Option, Parameter> mapOptionToParameter = new HashMap<Option, Parameter>();
+
+                for (Parameter parameter : importModuleFactory.getImportModuleParameters().getParameters()) {
+                        Option option = parameter.toOption("i");
+                        options.addOption(option);
+                        mapOptionToParameter.put(option, parameter);
+                }
+                for (ParameterGroup parameterGroup : importModuleFactory.getImportModuleParameters().getGroups()) {
+                        OptionGroup optionGroup = parameterGroup.toOptionGroup("i");
+                        options.addOptionGroup(optionGroup);
+
+                        for (Parameter parameter : parameterGroup.getParameters()) {
+                                mapOptionToParameter.put(parameter.toOption("i"), parameter);
+                        }
+                }
+                for (Parameter parameter : exportModuleFactory.getExportModuleParameters().getParameters()) {
+                        Option option = parameter.toOption("e");
+                        options.addOption(option);
+                        mapOptionToParameter.put(option, parameter);
+                }
+                for (ParameterGroup parameterGroup : exportModuleFactory.getExportModuleParameters().getGroups()) {
+                        OptionGroup optionGroup = parameterGroup.toOptionGroup("e");
+                        options.addOptionGroup(optionGroup);
+
+                        for (Parameter parameter : parameterGroup.getParameters()) {
+                                mapOptionToParameter.put(parameter.toOption("e"), parameter);
+                        }
+                }
+
+                Option importOption = Option.builder("i").longOpt("import").hasArg().optionalArg(false).build();
+                Option exportOption = Option.builder("e").longOpt("export").hasArg().optionalArg(false).build();
+                options.addOption(importOption);
+                options.addOption(exportOption);
+
+                new HelpFormatter().printHelp(80, "dbptk", "\nModule Options:", options, null, true);
+
+                // parse the command line arguments with those options
+                try {
+                        commandLine = commandLineParser.parse(options, args.toArray(new String[] {}), false);
+                } catch (MissingOptionException e){
+                        // use long names instead of short names in the error message
+                        List<String> missingShort = e.getMissingOptions();
+                        List<String> missingLong = new ArrayList<String>();
+                        for (String shortOption : missingShort) {
+                                missingLong.add(options.getOption(shortOption).getLongOpt());
+                        }
+                        throw new MissingOptionException(missingLong);
+                }
+
+                // create arguments to pass to factory
+                HashMap<Parameter, String> importModuleArguments = new HashMap<Parameter, String>();
+                for (Option option : commandLine.getOptions()) {
+                        System.out.print("...");
+                }
+        }
+
+        public void printHelp() {
+                printHelp(System.out);
+        }
+
+        public void printHelp(PrintStream printStream) {
                 StringBuilder out = new StringBuilder();
 
-                out.append("Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
+                out.append(
+                  "Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
 
-                ArrayList<ModuleInfo> modulesList = new ArrayList<ModuleInfo>(modulesInfo.values());
-                Collections.sort(modulesList);
+                ArrayList<DatabaseModuleFactory> modulesList = new ArrayList<DatabaseModuleFactory>(factories);
+                Collections.sort(modulesList, new DatabaseModuleFactoryNameComparator());
                 int textOffset = 0;
 
-                out.append("Available import modules:\n");
-                for (ModuleInfo moduleInfo : modulesList) {
-                        if(moduleInfo.isImportModule()){
+                out.append("Available import modules: -i <module>, --import=module\n");
+                for (DatabaseModuleFactory factory : modulesList) {
+                        if (factory.producesImportModules()) {
 
                         }
                 }
 
-                out.append("Available export modules:\n");
-                for (ModuleInfo moduleInfo : modulesList) {
-                        if(moduleInfo.isExportModule()){
+                out.append("Available export modules: -e <module>, --export=module\n");
+                for (DatabaseModuleFactory factory : modulesList) {
+                        if (factory.producesExportModules()) {
 
                         }
                 }
         }
 
-        private static class ModuleInfo implements Comparable<ModuleInfo>{
-                private String name;
-                private Parameters importParameters;
-                private Parameters exportParameters;
-                private boolean importModule;
-                private boolean exportModule;
-
-                public ModuleInfo(String name, boolean importModule, Parameters importParameters, boolean exportModule,
-                  Parameters exportParameters) {
-                        this.exportParameters = exportParameters;
-                        this.importParameters = importParameters;
-                        this.name = name;
-                        this.importModule = importModule;
-                        this.exportModule = exportModule;
-                }
-
-                public boolean isExportModule() {
-                        return exportModule;
-                }
-
-                public boolean isImportModule() {
-                        return importModule;
-                }
-
-                public Parameters getExportParameters() {
-                        return exportParameters;
-                }
-
-                public Parameters getImportParameters() {
-                        return importParameters;
-                }
-
-                public String getName() {
-                        return name;
-                }
-
-                @Override public int compareTo(ModuleInfo o) {
-                        return this.name.compareTo(o.getName());
+        private static class DatabaseModuleFactoryNameComparator implements Comparator<DatabaseModuleFactory> {
+                @Override public int compare(DatabaseModuleFactory o1, DatabaseModuleFactory o2) {
+                        return o1.getModuleName().compareTo(o2.getModuleName());
                 }
         }
 }

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -1,0 +1,150 @@
+package com.databasepreservation.cli;
+
+import com.databasepreservation.Main;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import com.sun.tools.javac.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Handles command line interface
+ *
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class CLI {
+        private final Map<Class<? extends DatabaseModuleFactory>, ModuleInfo> modulesInfo;
+
+        private static Class<? extends DatabaseModuleFactory>[] getModuleFactoriesFromConfiguration(){
+                InputStream cliPropertiesStream = CLI.class.getResourceAsStream("/config/cli.properties");
+                Properties cliProperties = new Properties();
+                try {
+                        cliProperties.load(cliPropertiesStream);
+                } catch (IOException e) {
+                        e.printStackTrace();
+                }
+                String module = (String)cliProperties.get("modules");
+
+                Class<?> aClass = null;
+                try {
+                        aClass = Class.forName(module);
+                } catch (ClassNotFoundException e) {
+                        e.printStackTrace();
+                }
+
+                Class<? extends DatabaseModuleFactory> aClass1 = null;
+                if(aClass.isAssignableFrom(DatabaseModuleFactory.class)){
+                        aClass1 = aClass.asSubclass(DatabaseModuleFactory.class);
+                }
+
+                ArrayList<Class<? extends DatabaseModuleFactory>> list = new ArrayList<Class<? extends DatabaseModuleFactory>>();
+                list.add(aClass1);
+
+                //return list.toArray(new Class<? extends DatabaseModuleFactory>[]{});
+                return null;
+        }
+
+        public CLI(){
+                this(getModuleFactoriesFromConfiguration());
+        }
+
+        public CLI(Class<? extends DatabaseModuleFactory>... databaseModuleFactory) {
+                modulesInfo = new HashMap<Class<? extends DatabaseModuleFactory>, ModuleInfo>();
+
+                try {
+                        for (Class<? extends DatabaseModuleFactory> factoryClass : databaseModuleFactory) {
+                                DatabaseModuleFactory factory = factoryClass.newInstance();
+
+                                modulesInfo.put(factoryClass,
+                                  new ModuleInfo(factory.getModuleName(), factory.producesImportModules(),
+                                    factory.getImportModuleParameters(), factory.producesExportModules(),
+                                    factory.getExportModuleParameters()));
+                        }
+                } catch (InstantiationException e) {
+                        e.printStackTrace();
+                } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                }
+        }
+
+        public void parse(String... args) {
+                // verificar (em args) quais são os módulos de import e export
+                // se não houver exactamente 1 export e 1 import, mostra o texto de ajuda
+                // só fazer a transformação de Parameter para Option nesses módulos (para não ter conflitos)
+                //
+
+        }
+
+        public void printHelp(PrintStream printStream){
+                StringBuilder out = new StringBuilder();
+
+                out.append("Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
+
+                ArrayList<ModuleInfo> modulesList = new ArrayList<ModuleInfo>(modulesInfo.values());
+                Collections.sort(modulesList);
+                int textOffset = 0;
+
+                out.append("Available import modules:\n");
+                for (ModuleInfo moduleInfo : modulesList) {
+                        if(moduleInfo.isImportModule()){
+
+                        }
+                }
+
+                out.append("Available export modules:\n");
+                for (ModuleInfo moduleInfo : modulesList) {
+                        if(moduleInfo.isExportModule()){
+
+                        }
+                }
+        }
+
+        private static class ModuleInfo implements Comparable<ModuleInfo>{
+                private String name;
+                private Parameters importParameters;
+                private Parameters exportParameters;
+                private boolean importModule;
+                private boolean exportModule;
+
+                public ModuleInfo(String name, boolean importModule, Parameters importParameters, boolean exportModule,
+                  Parameters exportParameters) {
+                        this.exportParameters = exportParameters;
+                        this.importParameters = importParameters;
+                        this.name = name;
+                        this.importModule = importModule;
+                        this.exportModule = exportModule;
+                }
+
+                public boolean isExportModule() {
+                        return exportModule;
+                }
+
+                public boolean isImportModule() {
+                        return importModule;
+                }
+
+                public Parameters getExportParameters() {
+                        return exportParameters;
+                }
+
+                public Parameters getImportParameters() {
+                        return importParameters;
+                }
+
+                public String getName() {
+                        return name;
+                }
+
+                @Override public int compareTo(ModuleInfo o) {
+                        return this.name.compareTo(o.getName());
+                }
+        }
+}

--- a/src/main/java/com/databasepreservation/cli/CLI.java
+++ b/src/main/java/com/databasepreservation/cli/CLI.java
@@ -254,11 +254,9 @@ public class CLI {
         private void printHelp(PrintStream printStream) {
                 StringBuilder out = new StringBuilder();
 
-                out.append("Database Preservation Toolkit, v")
-                  .append(getApplicationVersion())
-                  .append("\nMore info: http://www.database-preservation.com").append("\n")
-                  .append(
-                    "Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
+                out.append("Database Preservation Toolkit, v").append(getApplicationVersion())
+                  .append("\nMore info: http://www.database-preservation.com").append("\n").append(
+                  "Usage: dbptk <importModule> [import module options] <exportModule> [export module options]\n\n");
 
                 ArrayList<DatabaseModuleFactory> modulesList = new ArrayList<DatabaseModuleFactory>(factories);
                 Collections.sort(modulesList, new DatabaseModuleFactoryNameComparator());
@@ -268,7 +266,8 @@ public class CLI {
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesImportModules()) {
                                 try {
-                                        out.append(printModuleHelp("Import module: " + factory.getModuleName(), "i", factory.getImportModuleParameters()));
+                                        out.append(printModuleHelp("Import module: " + factory.getModuleName(), "i",
+                                          factory.getImportModuleParameters()));
                                 } catch (OperationNotSupportedException e) {
                                         //this should never happen
                                 }
@@ -279,7 +278,8 @@ public class CLI {
                 for (DatabaseModuleFactory factory : modulesList) {
                         if (factory.producesExportModules()) {
                                 try {
-                                        out.append(printModuleHelp("Export module: " + factory.getModuleName(), "e", factory.getExportModuleParameters()));
+                                        out.append(printModuleHelp("Export module: " + factory.getModuleName(), "e",
+                                          factory.getExportModuleParameters()));
                                 } catch (OperationNotSupportedException e) {
                                         //this should never happen
                                 }
@@ -289,7 +289,7 @@ public class CLI {
                 printStream.append(out).flush();
         }
 
-        private String printModuleHelp(String moduleDesignation, String parameterPrefix, Parameters moduleParameters){
+        private String printModuleHelp(String moduleDesignation, String parameterPrefix, Parameters moduleParameters) {
                 StringBuilder out = new StringBuilder();
 
                 String space = "    ";
@@ -310,32 +310,32 @@ public class CLI {
                 return out.toString();
         }
 
-        private String printParameterHelp(String space, String prefix, Parameter parameter){
+        private String printParameterHelp(String space, String prefix, Parameter parameter) {
                 StringBuilder out = new StringBuilder();
 
                 out.append("\n").append(space);
 
-                if(StringUtils.isNotBlank(parameter.shortName())){
+                if (StringUtils.isNotBlank(parameter.shortName())) {
                         out.append("-").append(prefix).append(parameter.shortName()).append(", ");
                 }
 
                 out.append("--").append(prefix).append(parameter.longName());
 
-                if(parameter.hasArgument()){
+                if (parameter.hasArgument()) {
                         out.append("=");
-                        if(parameter.isOptionalArgument()){
+                        if (parameter.isOptionalArgument()) {
                                 out.append("[");
                         }
                         out.append("value");
-                        if(parameter.isOptionalArgument()){
+                        if (parameter.isOptionalArgument()) {
                                 out.append("]");
                         }
                 }
 
                 out.append(space);
-                if(parameter.required()){
+                if (parameter.required()) {
                         out.append("(required) ");
-                }else{
+                } else {
                         out.append("(optional) ");
                 }
                 out.append(parameter.description());
@@ -343,7 +343,7 @@ public class CLI {
                 return out.toString();
         }
 
-        public static String getApplicationVersion(){
+        public static String getApplicationVersion() {
                 InputStream resourceAsStream = CLI.class
                   .getResourceAsStream("/META-INF/maven/pt.keep/db-preservation-toolkit/pom.properties");
                 Properties properties = new Properties();

--- a/src/main/java/com/databasepreservation/cli/Parameter.java
+++ b/src/main/java/com/databasepreservation/cli/Parameter.java
@@ -1,5 +1,9 @@
 package com.databasepreservation.cli;
 
+import org.apache.commons.cli.Option;
+
+import java.util.HashMap;
+
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
@@ -8,9 +12,12 @@ public class Parameter {
         private String longName = null;
         private String description = null;
         private boolean hasArgument = false;
+        private boolean optionalArgument = false;
         private boolean required = false;
         private String valueIfSet = null; //for parameters without argument
         private String valueIfNotSet = null; //for optional parameters that were not set
+
+        private HashMap<String, Option> options = new HashMap<String, Option>();
 
         public Parameter() {
         }
@@ -30,6 +37,15 @@ public class Parameter {
 
         public Parameter hasArgument(boolean hasArgument) {
                 this.hasArgument = hasArgument;
+                return this;
+        }
+
+        public boolean isOptionalArgument() {
+                return optionalArgument;
+        }
+
+        public Parameter setOptionalArgument(boolean optionalArgument) {
+                this.optionalArgument = optionalArgument;
                 return this;
         }
 
@@ -76,5 +92,21 @@ public class Parameter {
         public Parameter valueIfSet(String valueIfSet) {
                 this.valueIfSet = valueIfSet;
                 return this;
+        }
+
+        public Option toOption(String prefix) {
+                Option option = null;
+                if ((option = options.get(prefix)) == null) {
+                        if(shortName != null){
+                                option = Option.builder(prefix + shortName).longOpt(prefix + longName).desc(description)
+                                  .hasArg(hasArgument).required(required).optionalArg(optionalArgument).build();
+                        }else{
+                                option = Option.builder().longOpt(prefix + longName).desc(description)
+                                  .hasArg(hasArgument).required(required).optionalArg(optionalArgument).build();
+                        }
+
+                        options.put(prefix, option);
+                }
+                return option;
         }
 }

--- a/src/main/java/com/databasepreservation/cli/Parameter.java
+++ b/src/main/java/com/databasepreservation/cli/Parameter.java
@@ -1,0 +1,80 @@
+package com.databasepreservation.cli;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class Parameter {
+        private String shortName = null;
+        private String longName = null;
+        private String description = null;
+        private boolean hasArgument = false;
+        private boolean required = false;
+        private String valueIfSet = null; //for parameters without argument
+        private String valueIfNotSet = null; //for optional parameters that were not set
+
+        public Parameter() {
+        }
+
+        public String description() {
+                return description;
+        }
+
+        public Parameter description(String description) {
+                this.description = description;
+                return this;
+        }
+
+        public boolean hasArgument() {
+                return hasArgument;
+        }
+
+        public Parameter hasArgument(boolean hasArgument) {
+                this.hasArgument = hasArgument;
+                return this;
+        }
+
+        public String longName() {
+                return longName;
+        }
+
+        public Parameter longName(String longName) {
+                this.longName = longName;
+                return this;
+        }
+
+        public boolean required() {
+                return required;
+        }
+
+        public Parameter required(boolean required) {
+                this.required = required;
+                return this;
+        }
+
+        public String shortName() {
+                return shortName;
+        }
+
+        public Parameter shortName(String shortName) {
+                this.shortName = shortName;
+                return this;
+        }
+
+        public String valueIfNotSet() {
+                return valueIfNotSet;
+        }
+
+        public Parameter valueIfNotSet(String valueIfNotSet) {
+                this.valueIfNotSet = valueIfNotSet;
+                return this;
+        }
+
+        public String valueIfSet() {
+                return valueIfSet;
+        }
+
+        public Parameter valueIfSet(String valueIfSet) {
+                this.valueIfSet = valueIfSet;
+                return this;
+        }
+}

--- a/src/main/java/com/databasepreservation/cli/Parameter.java
+++ b/src/main/java/com/databasepreservation/cli/Parameter.java
@@ -97,10 +97,10 @@ public class Parameter {
         public Option toOption(String prefix) {
                 Option option = null;
                 if ((option = options.get(prefix)) == null) {
-                        if(shortName != null){
+                        if (shortName != null) {
                                 option = Option.builder(prefix + shortName).longOpt(prefix + longName).desc(description)
                                   .hasArg(hasArgument).required(required).optionalArg(optionalArgument).build();
-                        }else{
+                        } else {
                                 option = Option.builder().longOpt(prefix + longName).desc(description)
                                   .hasArg(hasArgument).required(required).optionalArg(optionalArgument).build();
                         }

--- a/src/main/java/com/databasepreservation/cli/ParameterGroup.java
+++ b/src/main/java/com/databasepreservation/cli/ParameterGroup.java
@@ -1,19 +1,37 @@
 package com.databasepreservation.cli;
 
-import com.google.common.collect.ImmutableList;
+import org.apache.commons.cli.OptionGroup;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class ParameterGroup {
-        private boolean required;
-        private List<Parameter> parameters;
+        private final boolean required;
+        private final List<Parameter> parameters;
+        private HashMap<String, OptionGroup> optionGroups = new HashMap<String, OptionGroup>();
 
         public ParameterGroup(boolean required, Parameter... parameters) {
                 this.required = required;
                 this.parameters = Arrays.asList(parameters);
+        }
+
+        public List<Parameter> getParameters() {
+                return parameters;
+        }
+
+        public OptionGroup toOptionGroup(String prefix) {
+                OptionGroup optionGroup = null;
+                if ((optionGroup = optionGroups.get(prefix)) == null) {
+                        optionGroup = new OptionGroup();
+                        optionGroup.setRequired(required);
+                        for (Parameter parameter : parameters) {
+                                optionGroup.addOption(parameter.toOption(prefix));
+                        }
+                }
+                return optionGroup;
         }
 }

--- a/src/main/java/com/databasepreservation/cli/ParameterGroup.java
+++ b/src/main/java/com/databasepreservation/cli/ParameterGroup.java
@@ -1,0 +1,19 @@
+package com.databasepreservation.cli;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class ParameterGroup {
+        private boolean required;
+        private List<Parameter> parameters;
+
+        public ParameterGroup(boolean required, Parameter... parameters) {
+                this.required = required;
+                this.parameters = Arrays.asList(parameters);
+        }
+}

--- a/src/main/java/com/databasepreservation/cli/Parameters.java
+++ b/src/main/java/com/databasepreservation/cli/Parameters.java
@@ -1,0 +1,28 @@
+package com.databasepreservation.cli;
+
+import com.sun.istack.internal.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class Parameters {
+        private final List<Parameter> parameters;
+        private final List<ParameterGroup> groups;
+
+        public Parameters(@Nullable List<Parameter> parameters, @Nullable List<ParameterGroup> groups) {
+                if (parameters != null) {
+                        this.parameters = parameters;
+                } else {
+                        this.parameters = Collections.emptyList();
+                }
+
+                if (groups != null) {
+                        this.groups = groups;
+                } else {
+                        this.groups = Collections.emptyList();
+                }
+        }
+}

--- a/src/main/java/com/databasepreservation/cli/Parameters.java
+++ b/src/main/java/com/databasepreservation/cli/Parameters.java
@@ -1,6 +1,5 @@
 package com.databasepreservation.cli;
 
-
 import java.util.Collections;
 import java.util.List;
 
@@ -13,8 +12,9 @@ public class Parameters {
 
         /**
          * Used to store a list of parameters and parameter groups
+         *
          * @param parameters the (nullable) parameter list
-         * @param groups the (nullable) parameter group list
+         * @param groups     the (nullable) parameter group list
          */
         public Parameters(List<Parameter> parameters, List<ParameterGroup> groups) {
                 if (parameters != null) {

--- a/src/main/java/com/databasepreservation/cli/Parameters.java
+++ b/src/main/java/com/databasepreservation/cli/Parameters.java
@@ -1,7 +1,6 @@
 package com.databasepreservation.cli;
 
 import com.sun.istack.internal.Nullable;
-import org.apache.commons.cli.Options;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/databasepreservation/cli/Parameters.java
+++ b/src/main/java/com/databasepreservation/cli/Parameters.java
@@ -1,6 +1,5 @@
 package com.databasepreservation.cli;
 
-import com.sun.istack.internal.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -12,7 +11,12 @@ public class Parameters {
         private final List<Parameter> parameters;
         private final List<ParameterGroup> groups;
 
-        public Parameters(@Nullable List<Parameter> parameters, @Nullable List<ParameterGroup> groups) {
+        /**
+         * Used to store a list of parameters and parameter groups
+         * @param parameters the (nullable) parameter list
+         * @param groups the (nullable) parameter group list
+         */
+        public Parameters(List<Parameter> parameters, List<ParameterGroup> groups) {
                 if (parameters != null) {
                         this.parameters = parameters;
                 } else {

--- a/src/main/java/com/databasepreservation/cli/Parameters.java
+++ b/src/main/java/com/databasepreservation/cli/Parameters.java
@@ -1,6 +1,7 @@
 package com.databasepreservation.cli;
 
 import com.sun.istack.internal.Nullable;
+import org.apache.commons.cli.Options;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,5 +25,13 @@ public class Parameters {
                 } else {
                         this.groups = Collections.emptyList();
                 }
+        }
+
+        public List<ParameterGroup> getGroups() {
+                return groups;
+        }
+
+        public List<Parameter> getParameters() {
+                return parameters;
         }
 }

--- a/src/main/java/com/databasepreservation/modules/DatabaseExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/DatabaseExportModule.java
@@ -14,8 +14,7 @@ import java.util.Set;
 /**
  * @author Luis Faria
  */
-public interface DatabaseHandler {
-
+public interface DatabaseExportModule {
         /**
          * Initialize the database, this will be the first method called
          *

--- a/src/main/java/com/databasepreservation/modules/DatabaseImportModule.java
+++ b/src/main/java/com/databasepreservation/modules/DatabaseImportModule.java
@@ -15,7 +15,7 @@ public interface DatabaseImportModule {
          * Import the database model.
          *
          * @param databaseExportModule The database model handler to be called when importing the
-         *                        database.
+         *                             database.
          * @throws UnknownTypeException a type used in the original database structure is unknown and
          *                              cannot be mapped
          * @throws InvalidDataException the database data is not valid

--- a/src/main/java/com/databasepreservation/modules/DatabaseImportModule.java
+++ b/src/main/java/com/databasepreservation/modules/DatabaseImportModule.java
@@ -14,13 +14,13 @@ public interface DatabaseImportModule {
         /**
          * Import the database model.
          *
-         * @param databaseHandler The database model handler to be called when importing the
+         * @param databaseExportModule The database model handler to be called when importing the
          *                        database.
          * @throws UnknownTypeException a type used in the original database structure is unknown and
          *                              cannot be mapped
          * @throws InvalidDataException the database data is not valid
          * @throws ModuleException      generic module exception
          */
-        public void getDatabase(DatabaseHandler databaseHandler)
+        public void getDatabase(DatabaseExportModule databaseExportModule)
           throws ModuleException, UnknownTypeException, InvalidDataException;
 }

--- a/src/main/java/com/databasepreservation/modules/DatabaseModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/DatabaseModuleFactory.java
@@ -18,6 +18,8 @@ public interface DatabaseModuleFactory {
 
         String getModuleName();
 
+        Map<String, Parameter> getAllParameters();
+
         Parameters getImportModuleParameters();
 
         Parameters getExportModuleParameters();

--- a/src/main/java/com/databasepreservation/modules/DatabaseModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/DatabaseModuleFactory.java
@@ -1,0 +1,28 @@
+package com.databasepreservation.modules;
+
+import com.databasepreservation.cli.Parameter;
+import com.databasepreservation.cli.Parameters;
+
+import java.util.Map;
+
+/**
+ * Defines a factory used to create Import and Export Modules.
+ * This factory should also be able to inform the parameters needed to create a new import or export module.
+ *
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public interface DatabaseModuleFactory {
+        boolean producesImportModules();
+
+        boolean producesExportModules();
+
+        String getModuleName();
+
+        Parameters getImportModuleParameters();
+
+        Parameters getExportModuleParameters();
+
+        DatabaseImportModule buildImportModule(Map<Parameter, String> parameters);
+
+        DatabaseExportModule buildExportModule(Map<Parameter, String> parameters);
+}

--- a/src/main/java/com/databasepreservation/modules/DatabaseModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/DatabaseModuleFactory.java
@@ -3,6 +3,7 @@ package com.databasepreservation.modules;
 import com.databasepreservation.cli.Parameter;
 import com.databasepreservation.cli.Parameters;
 
+import javax.naming.OperationNotSupportedException;
 import java.util.Map;
 
 /**
@@ -20,11 +21,21 @@ public interface DatabaseModuleFactory {
 
         Map<String, Parameter> getAllParameters();
 
-        Parameters getImportModuleParameters();
+        Parameters getImportModuleParameters() throws OperationNotSupportedException;
 
-        Parameters getExportModuleParameters();
+        Parameters getExportModuleParameters() throws OperationNotSupportedException;
 
-        DatabaseImportModule buildImportModule(Map<Parameter, String> parameters);
+        DatabaseImportModule buildImportModule(Map<Parameter, String> parameters) throws OperationNotSupportedException;
 
-        DatabaseExportModule buildExportModule(Map<Parameter, String> parameters);
+        DatabaseExportModule buildExportModule(Map<Parameter, String> parameters) throws OperationNotSupportedException;
+
+        class ExceptionBuilder {
+                public static OperationNotSupportedException OperationNotSupportedExceptionForImportModule() {
+                        return new OperationNotSupportedException("Import module not available");
+                }
+
+                public static OperationNotSupportedException OperationNotSupportedExceptionForExportModule() {
+                        return new OperationNotSupportedException("Export module not available");
+                }
+        }
 }

--- a/src/main/java/com/databasepreservation/modules/SQLHelper.java
+++ b/src/main/java/com/databasepreservation/modules/SQLHelper.java
@@ -323,11 +323,11 @@ public class SQLHelper {
                         for (Cell cell : row.getCells()) {
                                 ColumnStructure column = columnIt.next();
                                 if (i++ > 0) {
-                                        sqlOut.write(", " .getBytes());
+                                        sqlOut.write(", ".getBytes());
                                 }
                                 sqlOut.write(cellSQLHandler.createCellSQL(cell, column));
                         }
-                        sqlOut.write(")" .getBytes());
+                        sqlOut.write(")".getBytes());
                 } catch (IOException e) {
                         throw new ModuleException("Error creating row SQL", e);
                 }

--- a/src/main/java/com/databasepreservation/modules/db2/DB2ModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/db2/DB2ModuleFactory.java
@@ -1,13 +1,12 @@
-package com.databasepreservation.modules.postgreSql;
+package com.databasepreservation.modules.db2;
 
 import com.databasepreservation.cli.Parameter;
 import com.databasepreservation.cli.Parameters;
 import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.DatabaseModuleFactory;
-import com.databasepreservation.modules.postgreSql.in.PostgreSQLJDBCImportModule;
-import com.databasepreservation.modules.postgreSql.out.PostgreSQLJDBCExportModule;
-import org.apache.commons.lang3.StringUtils;
+import com.databasepreservation.modules.db2.in.DB2JDBCImportModule;
+import com.databasepreservation.modules.db2.out.DB2JDBCExportModule;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.Arrays;
@@ -17,13 +16,16 @@ import java.util.Map;
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
-public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
+public class DB2ModuleFactory implements DatabaseModuleFactory {
         private static final Parameter hostname = new Parameter().shortName("h").longName("hostname")
-          .description("the name of the PostgreSQL server host (e.g. localhost)").hasArgument(true)
-          .setOptionalArgument(false).required(true);
+          .description("the host name of Db2 Server").hasArgument(true).setOptionalArgument(false).required(true);
+
+        private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
+          .description("the port that the Db2 server is listening").hasArgument(true).setOptionalArgument(false)
+          .required(true);
 
         private static final Parameter database = new Parameter().shortName("db").longName("database")
-          .description("the name of the database to connect to").hasArgument(true).setOptionalArgument(false)
+          .description("the name of the database to import from").hasArgument(true).setOptionalArgument(false)
           .required(true);
 
         private static final Parameter username = new Parameter().shortName("u").longName("username")
@@ -34,14 +36,6 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
           .description("the password of the user to use in connection").hasArgument(true).setOptionalArgument(false)
           .required(true);
 
-        private static final Parameter dontEncrypt = new Parameter().shortName("ne").longName("do-not-encrypt")
-          .description("use to turn off encryption in the connection").hasArgument(false).required(false)
-          .valueIfNotSet("false").valueIfSet("true");
-
-        private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
-          .description("the port of where the PostgreSQL server is listening, default is 5432").hasArgument(true)
-          .setOptionalArgument(false).required(false).valueIfNotSet("5432");
-
         @Override public boolean producesImportModules() {
                 return true;
         }
@@ -51,7 +45,7 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
         }
 
         @Override public String getModuleName() {
-                return "PostgreSQLJDBC";
+                return "DB2JDBC";
         }
 
         @Override public Map<String, Parameter> getAllParameters() {
@@ -60,19 +54,16 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
                 parameterHashMap.put(database.longName(), database);
                 parameterHashMap.put(username.longName(), username);
                 parameterHashMap.put(password.longName(), password);
-                parameterHashMap.put(dontEncrypt.longName(), dontEncrypt);
                 parameterHashMap.put(portNumber.longName(), portNumber);
                 return parameterHashMap;
         }
 
         @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
-                return new Parameters(Arrays.asList(hostname, database, username, password, dontEncrypt, portNumber),
-                  null);
+                return new Parameters(Arrays.asList(hostname, database, username, password, portNumber), null);
         }
 
         @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
-                return new Parameters(Arrays.asList(hostname, database, username, password, dontEncrypt, portNumber),
-                  null);
+                return new Parameters(Arrays.asList(hostname, database, username, password, portNumber), null);
         }
 
         @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)
@@ -81,20 +72,9 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
                 String pDatabase = parameters.get(database);
                 String pUsername = parameters.get(username);
                 String pPassword = parameters.get(password);
+                Integer pPortNumber = Integer.parseInt(parameters.get(portNumber));
 
-                // boolean
-                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
-
-                // optional
-                Integer pPortNumber = null;
-                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
-                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
-                } else {
-                        pPortNumber = Integer.parseInt(portNumber.valueIfNotSet());
-                }
-
-                return new PostgreSQLJDBCImportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword,
-                  pEncrypt);
+                return new DB2JDBCImportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword);
         }
 
         @Override public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters)
@@ -103,19 +83,8 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
                 String pDatabase = parameters.get(database);
                 String pUsername = parameters.get(username);
                 String pPassword = parameters.get(password);
+                Integer pPortNumber = Integer.parseInt(parameters.get(portNumber));
 
-                // boolean
-                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
-
-                // optional
-                Integer pPortNumber = null;
-                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
-                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
-                } else {
-                        pPortNumber = Integer.parseInt(portNumber.valueIfNotSet());
-                }
-
-                return new PostgreSQLJDBCExportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword,
-                  pEncrypt);
+                return new DB2JDBCExportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword);
         }
 }

--- a/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -35,7 +35,7 @@ import com.databasepreservation.model.structure.type.SimpleTypeNumericExact;
 import com.databasepreservation.model.structure.type.SimpleTypeString;
 import com.databasepreservation.model.structure.type.Type;
 import com.databasepreservation.model.structure.type.UnsupportedDataType;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.SQLHelper;
 import org.apache.commons.lang3.StringUtils;
@@ -1527,7 +1527,7 @@ public class JDBCImportModule implements DatabaseImportModule {
                 return ignore;
         }
 
-        @Override public void getDatabase(DatabaseHandler handler)
+        @Override public void getDatabase(DatabaseExportModule handler)
           throws ModuleException, UnknownTypeException, InvalidDataException {
                 try {
                         logger.debug("initializing database");

--- a/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -599,7 +599,7 @@ public class JDBCImportModule implements DatabaseImportModule {
                         // YES --- if the column can include NULLs
                         // NO --- if the column cannot include NULLs
                         // empty string --- if the nullability for the column is unknown
-                        Boolean isNullable = "YES" .equals(rs.getString(18));
+                        Boolean isNullable = "YES".equals(rs.getString(18));
                         cLogMessage.append("Is Nullable: ").append(isNullable).append("\n");
                         // 20. SCOPE_SCHEMA String => schema of table that is the scope of a
                         // reference attribute (null if the DATA_TYPE isn't REF)
@@ -614,7 +614,7 @@ public class JDBCImportModule implements DatabaseImportModule {
                         // NO --- if the column is not auto incremented
                         // empty string --- if it cannot be determined whether the column is
                         // auto incremented
-                        Boolean isAutoIncrement = "YES" .equals(rs.getString(23));
+                        Boolean isAutoIncrement = "YES".equals(rs.getString(23));
                         cLogMessage.append("Is auto increment: ").append(isAutoIncrement).append("\n");
                         // 24. IS_GENERATEDCOLUMN String => Indicates whether this is a
                         // generated column

--- a/src/main/java/com/databasepreservation/modules/jdbc/out/JDBCExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/jdbc/out/JDBCExportModule.java
@@ -25,7 +25,6 @@ import com.databasepreservation.model.structure.type.SimpleTypeString;
 import com.databasepreservation.model.structure.type.Type;
 import com.databasepreservation.model.structure.type.UnsupportedDataType;
 import com.databasepreservation.modules.DatabaseExportModule;
-import com.databasepreservation.modules.DatabaseModuleFactory;
 import com.databasepreservation.modules.SQLHelper;
 import org.apache.log4j.Logger;
 import org.w3c.util.InvalidDateException;

--- a/src/main/java/com/databasepreservation/modules/jdbc/out/JDBCExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/jdbc/out/JDBCExportModule.java
@@ -24,7 +24,8 @@ import com.databasepreservation.model.structure.type.SimpleTypeNumericExact;
 import com.databasepreservation.model.structure.type.SimpleTypeString;
 import com.databasepreservation.model.structure.type.Type;
 import com.databasepreservation.model.structure.type.UnsupportedDataType;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
 import com.databasepreservation.modules.SQLHelper;
 import org.apache.log4j.Logger;
 import org.w3c.util.InvalidDateException;
@@ -52,8 +53,7 @@ import java.util.Set;
 /**
  * @author Luis Faria
  */
-public class JDBCExportModule implements DatabaseHandler {
-
+public class JDBCExportModule implements DatabaseExportModule {
         protected static final boolean DEFAULT_CAN_DROP_DATABASE = false;
         protected static int BATCH_SIZE = 100;
         protected final String driverClassName;

--- a/src/main/java/com/databasepreservation/modules/mySql/MySQLHelper.java
+++ b/src/main/java/com/databasepreservation/modules/mySql/MySQLHelper.java
@@ -122,8 +122,10 @@ public class MySQLHelper extends SQLHelper {
                         SimpleTypeBinary binary = (SimpleTypeBinary) type;
                         Integer length = binary.getLength();
                         if (length != null) {
-                                if (type.getSql99TypeName().equalsIgnoreCase("BIT") || StringUtils.startsWithIgnoreCase(type.getSql99TypeName(),"BIT(")) {
-                                        if (type.getOriginalTypeName().equalsIgnoreCase("BIT") || StringUtils.startsWithIgnoreCase(type.getOriginalTypeName(),"BIT(")) {
+                                if (type.getSql99TypeName().equalsIgnoreCase("BIT") || StringUtils
+                                  .startsWithIgnoreCase(type.getSql99TypeName(), "BIT(")) {
+                                        if (type.getOriginalTypeName().equalsIgnoreCase("BIT") || StringUtils
+                                          .startsWithIgnoreCase(type.getOriginalTypeName(), "BIT(")) {
                                                 ret = "bit(" + length + ")";
                                         } else {
                                                 ret = "binary(" + (((length / 8.0) % 1 == 0) ?

--- a/src/main/java/com/databasepreservation/modules/mySql/MySQLModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/mySql/MySQLModuleFactory.java
@@ -1,0 +1,109 @@
+package com.databasepreservation.modules.mySql;
+
+import com.databasepreservation.cli.Parameter;
+import com.databasepreservation.cli.Parameters;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import com.databasepreservation.modules.mySql.in.MySQLJDBCImportModule;
+import com.databasepreservation.modules.mySql.out.MySQLJDBCExportModule;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.naming.OperationNotSupportedException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class MySQLModuleFactory implements DatabaseModuleFactory {
+        private static final Parameter hostname = new Parameter().shortName("h").longName("hostname")
+          .description("the hostname of the MySQL server").hasArgument(true).setOptionalArgument(false).required(true);
+
+        private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
+          .description("the port that the MySQL server is listening").hasArgument(true).setOptionalArgument(false)
+          .required(false);
+
+        private static final Parameter database = new Parameter().shortName("db").longName("database")
+          .description("the name of the database to import from").hasArgument(true).setOptionalArgument(false)
+          .required(true);
+
+        private static final Parameter username = new Parameter().shortName("u").longName("username")
+          .description("the name of the user to use in connection").hasArgument(true).setOptionalArgument(false)
+          .required(true);
+
+        private static final Parameter password = new Parameter().shortName("p").longName("password")
+          .description("the password of the user to use in connection").hasArgument(true).setOptionalArgument(false)
+          .required(true);
+
+        @Override public boolean producesImportModules() {
+                return true;
+        }
+
+        @Override public boolean producesExportModules() {
+                return true;
+        }
+
+        @Override public String getModuleName() {
+                return "MySQLJDBC";
+        }
+
+        @Override public Map<String, Parameter> getAllParameters() {
+                HashMap<String, Parameter> parameterHashMap = new HashMap<String, Parameter>();
+                parameterHashMap.put(hostname.longName(), hostname);
+                parameterHashMap.put(database.longName(), database);
+                parameterHashMap.put(username.longName(), username);
+                parameterHashMap.put(password.longName(), password);
+                parameterHashMap.put(portNumber.longName(), portNumber);
+                return parameterHashMap;
+        }
+
+        @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(hostname, database, username, password, portNumber), null);
+        }
+
+        @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(hostname, database, username, password, portNumber), null);
+        }
+
+        @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pHostname = parameters.get(hostname);
+                String pDatabase = parameters.get(database);
+                String pUsername = parameters.get(username);
+                String pPassword = parameters.get(password);
+
+                // optional
+                Integer pPortNumber = null;
+                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
+                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                }
+
+                if (pPortNumber == null) {
+                        return new MySQLJDBCImportModule(pHostname, pDatabase, pUsername, pPassword);
+                } else {
+                        return new MySQLJDBCImportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword);
+                }
+        }
+
+        @Override public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pHostname = parameters.get(hostname);
+                String pDatabase = parameters.get(database);
+                String pUsername = parameters.get(username);
+                String pPassword = parameters.get(password);
+
+                // optional
+                Integer pPortNumber = null;
+                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
+                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                }
+
+                if (pPortNumber == null) {
+                        return new MySQLJDBCExportModule(pHostname, pDatabase, pUsername, pPassword);
+                } else {
+                        return new MySQLJDBCExportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword);
+                }
+        }
+}

--- a/src/main/java/com/databasepreservation/modules/postgreSql/PostgreSQLModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/postgreSql/PostgreSQLModuleFactory.java
@@ -34,9 +34,9 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
           .description("the password of the user to use in connection").hasArgument(true).setOptionalArgument(false)
           .required(true);
 
-        private static final Parameter disableEncryption = new Parameter().shortName("de").longName("disable-encryption")
-          .description("use to turn off encryption in the connection").hasArgument(false).required(false)
-          .valueIfNotSet("false").valueIfSet("true");
+        private static final Parameter disableEncryption = new Parameter().shortName("de")
+          .longName("disable-encryption").description("use to turn off encryption in the connection").hasArgument(false)
+          .required(false).valueIfNotSet("false").valueIfSet("true");
 
         private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
           .description("the port of where the PostgreSQL server is listening, default is 5432").hasArgument(true)
@@ -66,13 +66,13 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
         }
 
         @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
-                return new Parameters(Arrays.asList(hostname, database, username, password, disableEncryption, portNumber),
-                  null);
+                return new Parameters(
+                  Arrays.asList(hostname, database, username, password, disableEncryption, portNumber), null);
         }
 
         @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
-                return new Parameters(Arrays.asList(hostname, database, username, password, disableEncryption, portNumber),
-                  null);
+                return new Parameters(
+                  Arrays.asList(hostname, database, username, password, disableEncryption, portNumber), null);
         }
 
         @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)

--- a/src/main/java/com/databasepreservation/modules/postgreSql/PostgreSQLModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/postgreSql/PostgreSQLModuleFactory.java
@@ -1,0 +1,121 @@
+package com.databasepreservation.modules.postgreSql;
+
+import com.databasepreservation.cli.Parameter;
+import com.databasepreservation.cli.Parameters;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import com.databasepreservation.modules.postgreSql.in.PostgreSQLJDBCImportModule;
+import com.databasepreservation.modules.postgreSql.out.PostgreSQLJDBCExportModule;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.naming.OperationNotSupportedException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
+        private static final Parameter hostname = new Parameter().shortName("h").longName("hostname")
+          .description("the name of the PostgreSQL server host (e.g. localhost)").hasArgument(true)
+          .setOptionalArgument(false).required(true);
+
+        private static final Parameter database = new Parameter().shortName("db").longName("database")
+          .description("the name of the database to connect to").hasArgument(true).setOptionalArgument(false)
+          .required(true);
+
+        private static final Parameter username = new Parameter().shortName("u").longName("username")
+          .description("the name of the user to use in connection").hasArgument(true).setOptionalArgument(false)
+          .required(true);
+
+        private static final Parameter password = new Parameter().shortName("p").longName("password")
+          .description("the password of the user to use in connection").hasArgument(true).setOptionalArgument(false)
+          .required(true);
+
+        private static final Parameter dontEncrypt = new Parameter().shortName("ne").longName("do-not-encrypt")
+          .description("use to turn off encryption in the connection").hasArgument(false).required(false)
+          .valueIfNotSet("false").valueIfSet("true");
+
+        private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
+          .description("the port of where the PostgreSQL server is listening, default is 5432").hasArgument(true)
+          .setOptionalArgument(false).required(false).valueIfNotSet("5432");
+
+        @Override public boolean producesImportModules() {
+                return true;
+        }
+
+        @Override public boolean producesExportModules() {
+                return true;
+        }
+
+        @Override public String getModuleName() {
+                return "PostgreSQL";
+        }
+
+        @Override public Map<String, Parameter> getAllParameters() {
+                HashMap<String, Parameter> parameterHashMap = new HashMap<String, Parameter>();
+                parameterHashMap.put(hostname.longName(), hostname);
+                parameterHashMap.put(database.longName(), database);
+                parameterHashMap.put(username.longName(), username);
+                parameterHashMap.put(password.longName(), password);
+                parameterHashMap.put(dontEncrypt.longName(), dontEncrypt);
+                parameterHashMap.put(portNumber.longName(), portNumber);
+                return parameterHashMap;
+        }
+
+        @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(hostname, database, username, password, dontEncrypt, portNumber),
+                  null);
+        }
+
+        @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(hostname, database, username, password, dontEncrypt, portNumber),
+                  null);
+        }
+
+        @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pHostname = parameters.get(hostname);
+                String pDatabase = parameters.get(database);
+                String pUsername = parameters.get(username);
+                String pPassword = parameters.get(password);
+
+                // boolean
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+
+                // optional
+                Integer pPortNumber = null;
+                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
+                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                } else {
+                        pPortNumber = Integer.parseInt(portNumber.valueIfNotSet());
+                }
+
+                return new PostgreSQLJDBCImportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword,
+                  pEncrypt);
+        }
+
+        @Override public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pHostname = parameters.get(hostname);
+                String pDatabase = parameters.get(database);
+                String pUsername = parameters.get(username);
+                String pPassword = parameters.get(password);
+
+                // boolean
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+
+                // optional
+                Integer pPortNumber = null;
+                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
+                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                } else {
+                        pPortNumber = Integer.parseInt(portNumber.valueIfNotSet());
+                }
+
+                return new PostgreSQLJDBCExportModule(pHostname, pPortNumber, pDatabase, pUsername, pPassword,
+                  pEncrypt);
+        }
+}

--- a/src/main/java/com/databasepreservation/modules/postgreSql/PostgreSQLModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/postgreSql/PostgreSQLModuleFactory.java
@@ -34,7 +34,7 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
           .description("the password of the user to use in connection").hasArgument(true).setOptionalArgument(false)
           .required(true);
 
-        private static final Parameter dontEncrypt = new Parameter().shortName("ne").longName("do-not-encrypt")
+        private static final Parameter disableEncryption = new Parameter().shortName("de").longName("disable-encryption")
           .description("use to turn off encryption in the connection").hasArgument(false).required(false)
           .valueIfNotSet("false").valueIfSet("true");
 
@@ -60,18 +60,18 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
                 parameterHashMap.put(database.longName(), database);
                 parameterHashMap.put(username.longName(), username);
                 parameterHashMap.put(password.longName(), password);
-                parameterHashMap.put(dontEncrypt.longName(), dontEncrypt);
+                parameterHashMap.put(disableEncryption.longName(), disableEncryption);
                 parameterHashMap.put(portNumber.longName(), portNumber);
                 return parameterHashMap;
         }
 
         @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
-                return new Parameters(Arrays.asList(hostname, database, username, password, dontEncrypt, portNumber),
+                return new Parameters(Arrays.asList(hostname, database, username, password, disableEncryption, portNumber),
                   null);
         }
 
         @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
-                return new Parameters(Arrays.asList(hostname, database, username, password, dontEncrypt, portNumber),
+                return new Parameters(Arrays.asList(hostname, database, username, password, disableEncryption, portNumber),
                   null);
         }
 
@@ -83,7 +83,7 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
                 String pPassword = parameters.get(password);
 
                 // boolean
-                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(disableEncryption));
 
                 // optional
                 Integer pPortNumber = null;
@@ -105,7 +105,7 @@ public class PostgreSQLModuleFactory implements DatabaseModuleFactory {
                 String pPassword = parameters.get(password);
 
                 // boolean
-                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(disableEncryption));
 
                 // optional
                 Integer pPortNumber = null;

--- a/src/main/java/com/databasepreservation/modules/siard/SIARD1ModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/siard/SIARD1ModuleFactory.java
@@ -1,0 +1,85 @@
+package com.databasepreservation.modules.siard;
+
+import com.databasepreservation.cli.Parameter;
+import com.databasepreservation.cli.Parameters;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import com.databasepreservation.modules.siard.in.input.SIARD1ImportModule;
+import com.databasepreservation.modules.siard.out.output.SIARD1ExportModule;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.naming.OperationNotSupportedException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class SIARD1ModuleFactory implements DatabaseModuleFactory {
+        private static final Parameter file = new Parameter().shortName("f").longName("file")
+          .description("Path to SIARD1 archive file").hasArgument(true).setOptionalArgument(false).required(true);
+
+        private static final Parameter compress = new Parameter().shortName("c").longName("compress")
+          .description("use to compress the SIARD1 archive file with deflate method").hasArgument(false).required(false)
+          .valueIfNotSet("false").valueIfSet("true");
+
+        private static final Parameter prettyPrintXML = new Parameter().shortName("p").longName("pretty-xml")
+          .description("write human-readable XML").hasArgument(false).required(false).valueIfNotSet("false")
+          .valueIfSet("true");
+
+        @Override public boolean producesImportModules() {
+                return true;
+        }
+
+        @Override public boolean producesExportModules() {
+                return true;
+        }
+
+        @Override public String getModuleName() {
+                return "SIARD1";
+        }
+
+        @Override public Map<String, Parameter> getAllParameters() {
+                HashMap<String, Parameter> parameterHashMap = new HashMap<String, Parameter>();
+                parameterHashMap.put(file.longName(), file);
+                parameterHashMap.put(compress.longName(), compress);
+                parameterHashMap.put(prettyPrintXML.longName(), prettyPrintXML);
+                return parameterHashMap;
+        }
+
+        @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(file), null);
+        }
+
+        @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(file, compress, prettyPrintXML), null);
+        }
+
+        @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pFile = parameters.get(file);
+                return new SIARD1ImportModule(Paths.get(pFile)).getDatabaseImportModule();
+        }
+
+        @Override public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pFile = parameters.get(file);
+
+                // optional
+                boolean pCompress = Boolean.parseBoolean(compress.valueIfNotSet());
+                if (StringUtils.isNotBlank(parameters.get(compress))) {
+                        pCompress = Boolean.parseBoolean(compress.valueIfSet());
+                }
+
+                boolean pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfNotSet());
+                if (StringUtils.isNotBlank(parameters.get(prettyPrintXML))) {
+                        pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfSet());
+                }
+
+                // TODO: prettyXML
+                return new SIARD1ExportModule(Paths.get(pFile), pCompress).getDatabaseHandler();
+        }
+}

--- a/src/main/java/com/databasepreservation/modules/siard/SIARD2ModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/siard/SIARD2ModuleFactory.java
@@ -1,0 +1,93 @@
+package com.databasepreservation.modules.siard;
+
+import com.databasepreservation.cli.Parameter;
+import com.databasepreservation.cli.Parameters;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import com.databasepreservation.modules.siard.in.input.SIARD2ImportModule;
+import com.databasepreservation.modules.siard.out.output.SIARD2ExportModule;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.naming.OperationNotSupportedException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class SIARD2ModuleFactory implements DatabaseModuleFactory {
+        private static final Parameter file = new Parameter().shortName("f").longName("file")
+          .description("Path to SIARD2 archive file").hasArgument(true).setOptionalArgument(false).required(true);
+
+        // TODO: check if this argument is really necessary
+        //private static final Parameter auxiliaryContainersInZipFormat = new Parameter().shortName("p")
+        //  .longName("pretty-xml").description(
+        //    "In some SIARD2 archives, LOBs are saved outside the main SIARD archive container. These LOBs "
+        //      + "may be saved in a ZIP or simply saved to folders. When reading those LOBs it's important "
+        //      + "to know if they are inside a simple folder or a zip container.").hasArgument(false).required(false)
+        //  .valueIfNotSet("false").valueIfSet("true");
+
+        private static final Parameter compress = new Parameter().shortName("c").longName("compress")
+          .description("use to compress the SIARD2 archive file with deflate method").hasArgument(false).required(false)
+          .valueIfNotSet("false").valueIfSet("true");
+
+        private static final Parameter prettyPrintXML = new Parameter().shortName("p").longName("pretty-xml")
+          .description("write human-readable XML").hasArgument(false).required(false).valueIfNotSet("false")
+          .valueIfSet("true");
+
+        @Override public boolean producesImportModules() {
+                return true;
+        }
+
+        @Override public boolean producesExportModules() {
+                return true;
+        }
+
+        @Override public String getModuleName() {
+                return "SIARD2";
+        }
+
+        @Override public Map<String, Parameter> getAllParameters() {
+                HashMap<String, Parameter> parameterHashMap = new HashMap<String, Parameter>();
+                parameterHashMap.put(file.longName(), file);
+                parameterHashMap.put(compress.longName(), compress);
+                parameterHashMap.put(prettyPrintXML.longName(), prettyPrintXML);
+                return parameterHashMap;
+        }
+
+        @Override public Parameters getImportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(file), null);
+        }
+
+        @Override public Parameters getExportModuleParameters() throws OperationNotSupportedException {
+                return new Parameters(Arrays.asList(file, compress, prettyPrintXML), null);
+        }
+
+        @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pFile = parameters.get(file);
+                return new SIARD2ImportModule(Paths.get(pFile)).getDatabaseImportModule();
+        }
+
+        @Override public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters)
+          throws OperationNotSupportedException {
+                String pFile = parameters.get(file);
+
+                // optional
+                boolean pCompress = Boolean.parseBoolean(compress.valueIfNotSet());
+                if (StringUtils.isNotBlank(parameters.get(compress))) {
+                        pCompress = Boolean.parseBoolean(compress.valueIfSet());
+                }
+
+                boolean pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfNotSet());
+                if (StringUtils.isNotBlank(parameters.get(prettyPrintXML))) {
+                        pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfSet());
+                }
+
+                // TODO: prettyXML
+                return new SIARD2ExportModule(Paths.get(pFile), pCompress).getDatabaseHandler();
+        }
+}

--- a/src/main/java/com/databasepreservation/modules/siard/SIARDHelper.java
+++ b/src/main/java/com/databasepreservation/modules/siard/SIARDHelper.java
@@ -46,7 +46,7 @@ public class SIARDHelper {
         }
 
         public static String bytesToHex(byte[] bytes) {
-                final char[] hexArray = "0123456789ABCDEF" .toCharArray();
+                final char[] hexArray = "0123456789ABCDEF".toCharArray();
                 char[] hexChars = new char[bytes.length * 2];
                 for (int j = 0; j < bytes.length; j++) {
                         int v = bytes[j] & 0xFF;

--- a/src/main/java/com/databasepreservation/modules/siard/common/path/MetadataPathStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/common/path/MetadataPathStrategy.java
@@ -1,22 +1,25 @@
 package com.databasepreservation.modules.siard.common.path;
 
+import java.security.InvalidParameterException;
+
 /**
- * Defines an API to get the locations of the main XML metadata file and the respective XML schema validator file.
- * the locations should be returned as relative paths as if the siard file was the root folder.
- * <p>
- * Example: to refer the file at ".../database.siard/header/metadata.xml", the value "header/metadata.xml"
- * should be returned.
+ * Defines an API to get the locations of the main XML metadata file and the
+ * respective XML schema validator file. the locations should be returned as
+ * relative paths as if the siard file was the root folder.
+ *
+ * Example: to refer the file at ".../database.siard/header/metadata.xml", the
+ * value "header/metadata.xml" should be returned.
  *
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public interface MetadataPathStrategy {
         /**
-         * Returns the path to the metadata.xml file
+         * Returns the path to the metedata XML-file with name filename
          */
-        public String getMetadataXmlFilePath();
+        public String getXmlFilePath(String filename) throws InvalidParameterException;
 
         /**
-         * Returns the path to the metadata.xsd file
+         * Returns the path to the metadata XSD-file with name filename
          */
-        public String getMetadataXsdFilePath();
+        public String getXsdFilePath(String filename) throws InvalidParameterException;
 }

--- a/src/main/java/com/databasepreservation/modules/siard/common/path/MetadataPathStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/common/path/MetadataPathStrategy.java
@@ -3,9 +3,9 @@ package com.databasepreservation.modules.siard.common.path;
 /**
  * Defines an API to get the locations of the main XML metadata file and the respective XML schema validator file.
  * the locations should be returned as relative paths as if the siard file was the root folder.
- *
+ * <p>
  * Example: to refer the file at ".../database.siard/header/metadata.xml", the value "header/metadata.xml"
- *          should be returned.
+ * should be returned.
  *
  * @author Bruno Ferreira <bferreira@keep.pt>
  */

--- a/src/main/java/com/databasepreservation/modules/siard/common/path/SIARD1MetadataPathStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/common/path/SIARD1MetadataPathStrategy.java
@@ -1,6 +1,7 @@
 package com.databasepreservation.modules.siard.common.path;
 
 import java.io.File;
+import java.security.InvalidParameterException;
 
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
@@ -20,13 +21,24 @@ public class SIARD1MetadataPathStrategy implements MetadataPathStrategy {
         private static final String FILE_SEPARATOR = File.separator; // is "/" on Unix and "\\" on Windows
         private static final String FILE_EXTENSION_SEPARATOR = ".";
 
-        @Override public String getMetadataXmlFilePath() {
-                return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
-                  .append(FILE_EXTENSION_SEPARATOR).append(XML_EXTENSION).toString();
+        @Override
+        public String getXmlFilePath(String filename) throws InvalidParameterException {
+
+                if (filename.equals(METADATA_FILENAME)) {
+                        return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
+                          .append(FILE_EXTENSION_SEPARATOR).append(XML_EXTENSION).toString();
+                } else {
+                        throw new InvalidParameterException("Invalid metadata filename");
+                }
         }
 
-        @Override public String getMetadataXsdFilePath() {
-                return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
-                  .append(FILE_EXTENSION_SEPARATOR).append(XSD_EXTENSION).toString();
+        @Override
+        public String getXsdFilePath(String filename) throws InvalidParameterException {
+                if (filename.equals(METADATA_FILENAME)) {
+                        return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
+                          .append(FILE_EXTENSION_SEPARATOR).append(XSD_EXTENSION).toString();
+                } else {
+                        throw new InvalidParameterException("Invalid metadata filename");
+                }
         }
 }

--- a/src/main/java/com/databasepreservation/modules/siard/common/path/SIARD2MetadataPathStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/common/path/SIARD2MetadataPathStrategy.java
@@ -1,6 +1,7 @@
 package com.databasepreservation.modules.siard.common.path;
 
 import java.io.File;
+import java.security.InvalidParameterException;
 
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
@@ -20,13 +21,24 @@ public class SIARD2MetadataPathStrategy implements MetadataPathStrategy {
         private static final String FILE_SEPARATOR = File.separator; // is "/" on Unix and "\\" on Windows
         private static final String FILE_EXTENSION_SEPARATOR = ".";
 
-        @Override public String getMetadataXmlFilePath() {
-                return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
-                  .append(FILE_EXTENSION_SEPARATOR).append(XML_EXTENSION).toString();
+        @Override
+        public String getXmlFilePath(String filename) throws InvalidParameterException {
+
+                if (filename.equals(METADATA_FILENAME)) {
+                        return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
+                          .append(FILE_EXTENSION_SEPARATOR).append(XML_EXTENSION).toString();
+                } else {
+                        throw new InvalidParameterException("Invalid metadata filename");
+                }
         }
 
-        @Override public String getMetadataXsdFilePath() {
-                return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
-                  .append(FILE_EXTENSION_SEPARATOR).append(XSD_EXTENSION).toString();
+        @Override
+        public String getXsdFilePath(String filename) throws InvalidParameterException {
+                if (filename.equals(METADATA_FILENAME)) {
+                        return new StringBuilder().append(HEADER_DIR).append(FILE_SEPARATOR).append(METADATA_FILENAME)
+                          .append(FILE_EXTENSION_SEPARATOR).append(XSD_EXTENSION).toString();
+                } else {
+                        throw new InvalidParameterException("Invalid metadata filename");
+                }
         }
 }

--- a/src/main/java/com/databasepreservation/modules/siard/in/content/ContentImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/content/ContentImportStrategy.java
@@ -2,13 +2,13 @@ package com.databasepreservation.modules.siard.in.content;
 
 import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.structure.DatabaseStructure;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public interface ContentImportStrategy {
-        void importContent(DatabaseHandler handler, SIARDArchiveContainer container,
+        void importContent(DatabaseExportModule handler, SIARDArchiveContainer container,
           DatabaseStructure databaseStructure) throws ModuleException;
 }

--- a/src/main/java/com/databasepreservation/modules/siard/in/content/SIARD1ContentImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/content/SIARD1ContentImportStrategy.java
@@ -13,7 +13,7 @@ import com.databasepreservation.model.structure.TableStructure;
 import com.databasepreservation.model.structure.type.SimpleTypeBinary;
 import com.databasepreservation.model.structure.type.SimpleTypeString;
 import com.databasepreservation.model.structure.type.Type;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.siard.SIARDHelper;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.in.path.ContentPathImportStrategy;
@@ -60,7 +60,7 @@ public class SIARD1ContentImportStrategy extends DefaultHandler implements Conte
         private final Stack<String> tagsStack = new Stack<String>();
         private final StringBuilder tempVal = new StringBuilder();
         private SIARDArchiveContainer contentContainer;
-        private DatabaseHandler databaseHandler;
+        private DatabaseExportModule databaseExportModule;
         private SAXErrorHandler errorHandler;
         // SAXHandler state
         private TableStructure currentTable;
@@ -75,10 +75,10 @@ public class SIARD1ContentImportStrategy extends DefaultHandler implements Conte
                 this.readStrategy = readStrategy;
         }
 
-        @Override public void importContent(DatabaseHandler handler, SIARDArchiveContainer container,
+        @Override public void importContent(DatabaseExportModule handler, SIARDArchiveContainer container,
           DatabaseStructure databaseStructure) throws ModuleException {
                 // set instance state
-                this.databaseHandler = handler;
+                this.databaseExportModule = handler;
                 this.contentContainer = container;
 
                 // pre-setup parser and validation
@@ -174,14 +174,14 @@ public class SIARD1ContentImportStrategy extends DefaultHandler implements Conte
 
                 if (qName.equalsIgnoreCase(SCHEMA_KEYWORD)) {
                         try {
-                                databaseHandler.handleDataOpenSchema(currentSchema.getName());
+                                databaseExportModule.handleDataOpenSchema(currentSchema.getName());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data open schema", e);
                         }
                 } else if (qName.equalsIgnoreCase(TABLE_KEYWORD)) {
                         this.rowIndex = 0;
                         try {
-                                databaseHandler.handleDataOpenTable(currentTable.getId());
+                                databaseExportModule.handleDataOpenTable(currentTable.getId());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data open table", e);
                         }
@@ -227,14 +227,14 @@ public class SIARD1ContentImportStrategy extends DefaultHandler implements Conte
 
                 if (tag.equalsIgnoreCase(SCHEMA_KEYWORD)) {
                         try {
-                                databaseHandler.handleDataCloseSchema(currentSchema.getName());
+                                databaseExportModule.handleDataCloseSchema(currentSchema.getName());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data close schema", e);
                         }
                 } else if (tag.equalsIgnoreCase(TABLE_KEYWORD)) {
                         try {
                                 logger.debug("before handle data close");
-                                databaseHandler.handleDataCloseTable(currentTable.getId());
+                                databaseExportModule.handleDataCloseTable(currentTable.getId());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data close table", e);
                         }
@@ -242,7 +242,7 @@ public class SIARD1ContentImportStrategy extends DefaultHandler implements Conte
                         row.setIndex(rowIndex);
                         rowIndex++;
                         try {
-                                databaseHandler.handleDataRow(row);
+                                databaseExportModule.handleDataRow(row);
                         } catch (InvalidDataException e) {
                                 logger.error("An error occurred while handling data row", e);
                         } catch (ModuleException e) {

--- a/src/main/java/com/databasepreservation/modules/siard/in/content/SIARD2ContentImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/content/SIARD2ContentImportStrategy.java
@@ -13,7 +13,7 @@ import com.databasepreservation.model.structure.TableStructure;
 import com.databasepreservation.model.structure.type.SimpleTypeBinary;
 import com.databasepreservation.model.structure.type.SimpleTypeString;
 import com.databasepreservation.model.structure.type.Type;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.siard.SIARDHelper;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.in.path.ContentPathImportStrategy;
@@ -60,7 +60,7 @@ public class SIARD2ContentImportStrategy extends DefaultHandler implements Conte
         private final Stack<String> tagsStack = new Stack<String>();
         private final StringBuilder tempVal = new StringBuilder();
         private SIARDArchiveContainer contentContainer;
-        private DatabaseHandler databaseHandler;
+        private DatabaseExportModule databaseExportModule;
         private SAXErrorHandler errorHandler;
         // SAXHandler state
         private TableStructure currentTable;
@@ -75,10 +75,10 @@ public class SIARD2ContentImportStrategy extends DefaultHandler implements Conte
                 this.readStrategy = readStrategy;
         }
 
-        @Override public void importContent(DatabaseHandler handler, SIARDArchiveContainer container,
+        @Override public void importContent(DatabaseExportModule handler, SIARDArchiveContainer container,
           DatabaseStructure databaseStructure) throws ModuleException {
                 // set instance state
-                this.databaseHandler = handler;
+                this.databaseExportModule = handler;
                 this.contentContainer = container;
 
                 // pre-setup parser and validation
@@ -174,14 +174,14 @@ public class SIARD2ContentImportStrategy extends DefaultHandler implements Conte
 
                 if (qName.equalsIgnoreCase(SCHEMA_KEYWORD)) {
                         try {
-                                databaseHandler.handleDataOpenSchema(currentSchema.getName());
+                                databaseExportModule.handleDataOpenSchema(currentSchema.getName());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data open schema", e);
                         }
                 } else if (qName.equalsIgnoreCase(TABLE_KEYWORD)) {
                         this.rowIndex = 0;
                         try {
-                                databaseHandler.handleDataOpenTable(currentTable.getId());
+                                databaseExportModule.handleDataOpenTable(currentTable.getId());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data open table", e);
                         }
@@ -208,14 +208,14 @@ public class SIARD2ContentImportStrategy extends DefaultHandler implements Conte
 
                 if (tag.equalsIgnoreCase(SCHEMA_KEYWORD)) {
                         try {
-                                databaseHandler.handleDataCloseSchema(currentSchema.getName());
+                                databaseExportModule.handleDataCloseSchema(currentSchema.getName());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data close schema", e);
                         }
                 } else if (tag.equalsIgnoreCase(TABLE_KEYWORD)) {
                         try {
                                 logger.debug("before handle data close");
-                                databaseHandler.handleDataCloseTable(currentTable.getId());
+                                databaseExportModule.handleDataCloseTable(currentTable.getId());
                         } catch (ModuleException e) {
                                 logger.error("An error occurred while handling data close table", e);
                         }
@@ -223,7 +223,7 @@ public class SIARD2ContentImportStrategy extends DefaultHandler implements Conte
                         row.setIndex(rowIndex);
                         rowIndex++;
                         try {
-                                databaseHandler.handleDataRow(row);
+                                databaseExportModule.handleDataRow(row);
                         } catch (InvalidDataException e) {
                                 logger.error("An error occurred while handling data row", e);
                         } catch (ModuleException e) {

--- a/src/main/java/com/databasepreservation/modules/siard/in/input/SIARD2ImportModule.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/input/SIARD2ImportModule.java
@@ -32,11 +32,11 @@ public class SIARD2ImportModule {
         /**
          * Constructor used to initialize required objects to get a database import module
          *
-         * @param siardPackage            Path to the main SIARD file (file with extension .siard)
+         * @param siardPackage                   Path to the main SIARD file (file with extension .siard)
          * @param auxiliaryContainersInZipFormat (optional) In some SIARD2 archives, LOBs are saved outside the main SIARD
-         *                                archive container. These LOBs may be saved in a ZIP or simply saved to folders.
-         *                                When reading those LOBs it's important to know if they are inside a simple
-         *                                folder or a zip container.
+         *                                       archive container. These LOBs may be saved in a ZIP or simply saved to folders.
+         *                                       When reading those LOBs it's important to know if they are inside a simple
+         *                                       folder or a zip container.
          */
         public SIARD2ImportModule(Path siardPackage, boolean auxiliaryContainersInZipFormat) {
                 mainContainer = new SIARDArchiveContainer(siardPackage, SIARDArchiveContainer.OutputContainerType.MAIN);

--- a/src/main/java/com/databasepreservation/modules/siard/in/input/SIARDImportDefault.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/input/SIARDImportDefault.java
@@ -4,7 +4,7 @@ import com.databasepreservation.model.exception.InvalidDataException;
 import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.exception.UnknownTypeException;
 import com.databasepreservation.model.structure.DatabaseStructure;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.in.content.ContentImportStrategy;
@@ -28,7 +28,7 @@ public class SIARDImportDefault implements DatabaseImportModule {
                 this.metadataStrategy = metadataStrategy;
         }
 
-        @Override public void getDatabase(DatabaseHandler handler)
+        @Override public void getDatabase(DatabaseExportModule handler)
           throws ModuleException, UnknownTypeException, InvalidDataException {
                 readStrategy.setup(mainContainer);
                 handler.initDatabase();

--- a/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD1MetadataImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD1MetadataImportStrategy.java
@@ -70,6 +70,8 @@ import java.util.List;
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class SIARD1MetadataImportStrategy implements MetadataImportStrategy {
+        private static final String METADATA_FILENAME = "metadata";
+
         private final MetadataPathStrategy metadataPathStrategy;
         private final ContentPathImportStrategy contentPathStrategy;
         private DatabaseStructure databaseStructure;
@@ -96,12 +98,12 @@ public class SIARD1MetadataImportStrategy implements MetadataImportStrategy {
                 SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
                 Schema xsdSchema = null;
                 InputStream xsdStream = readStrategy
-                  .createInputStream(container, metadataPathStrategy.getMetadataXsdFilePath());
+                  .createInputStream(container, metadataPathStrategy.getXsdFilePath(METADATA_FILENAME));
                 try {
                         xsdSchema = schemaFactory.newSchema(new StreamSource(xsdStream));
                 } catch (SAXException e) {
                         throw new ModuleException(
-                          "Error reading metadata XSD file: " + metadataPathStrategy.getMetadataXsdFilePath(), e);
+                          "Error reading metadata XSD file: " + metadataPathStrategy.getXsdFilePath(METADATA_FILENAME), e);
                 }
 
                 InputStream reader = null;
@@ -114,7 +116,7 @@ public class SIARD1MetadataImportStrategy implements MetadataImportStrategy {
                         unmarshaller.setSchema(xsdSchema);
 
                         reader = readStrategy
-                          .createInputStream(container, metadataPathStrategy.getMetadataXmlFilePath());
+                          .createInputStream(container, metadataPathStrategy.getXmlFilePath(METADATA_FILENAME));
                         xmlRoot = (SiardArchive) unmarshaller.unmarshal(reader);
                 } catch (JAXBException e) {
                         throw new ModuleException("Error while Unmarshalling JAXB", e);

--- a/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD1MetadataImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD1MetadataImportStrategy.java
@@ -52,7 +52,6 @@ import com.databasepreservation.modules.siard.in.metadata.typeConverter.TypeConv
 import com.databasepreservation.modules.siard.in.path.ContentPathImportStrategy;
 import com.databasepreservation.modules.siard.in.read.ReadStrategy;
 import com.databasepreservation.utils.JodaUtils;
-import org.apache.log4j.Logger;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;

--- a/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD2MetadataImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD2MetadataImportStrategy.java
@@ -52,7 +52,6 @@ import com.databasepreservation.modules.siard.in.metadata.typeConverter.TypeConv
 import com.databasepreservation.modules.siard.in.path.ContentPathImportStrategy;
 import com.databasepreservation.modules.siard.in.read.ReadStrategy;
 import com.databasepreservation.utils.JodaUtils;
-import org.apache.log4j.Logger;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
@@ -258,7 +257,7 @@ public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
                 return result;
         }
 
-        private SchemaStructure getSchemaStructure(SchemaType schema) throws ModuleException{
+        private SchemaStructure getSchemaStructure(SchemaType schema) throws ModuleException {
                 if (schema != null) {
                         SchemaStructure result = new SchemaStructure();
 
@@ -370,7 +369,8 @@ public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
                         result.setQuery(viewType.getQuery());
                         result.setQueryOriginal(viewType.getQueryOriginal());
                         result.setDescription(viewType.getDescription());
-                        result.setColumns(getColumns(viewType.getColumns(), "")); //TODO: decide what to put here as table name
+                        result.setColumns(
+                          getColumns(viewType.getColumns(), "")); //TODO: decide what to put here as table name
                         //TODO: result.setRows(getRows(viewType.getRows()));
 
                         return result;

--- a/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD2MetadataImportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD2MetadataImportStrategy.java
@@ -70,6 +70,8 @@ import java.util.List;
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
+        private static final String METADATA_FILENAME = "metadata";
+
         private DatabaseStructure databaseStructure;
         private final MetadataPathStrategy metadataPathStrategy;
         private final ContentPathImportStrategy contentPathStrategy;
@@ -95,12 +97,12 @@ public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
                 SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
                 Schema xsdSchema = null;
                 InputStream xsdStream = readStrategy
-                  .createInputStream(container, metadataPathStrategy.getMetadataXsdFilePath());
+                  .createInputStream(container, metadataPathStrategy.getXsdFilePath(METADATA_FILENAME));
                 try {
                         xsdSchema = schemaFactory.newSchema(new StreamSource(xsdStream));
                 } catch (SAXException e) {
                         throw new ModuleException(
-                          "Error reading metadata XSD file: " + metadataPathStrategy.getMetadataXsdFilePath(), e);
+                          "Error reading metadata XSD file: " + metadataPathStrategy.getXsdFilePath(METADATA_FILENAME), e);
                 }
 
                 InputStream reader = null;
@@ -111,7 +113,7 @@ public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
                         unmarshaller.setSchema(xsdSchema);
 
                         reader = readStrategy
-                          .createInputStream(container, metadataPathStrategy.getMetadataXmlFilePath());
+                          .createInputStream(container, metadataPathStrategy.getXmlFilePath(METADATA_FILENAME));
                         xmlRoot = (SiardArchive) unmarshaller.unmarshal(reader);
                 } catch (JAXBException e) {
                         throw new ModuleException("Error while Unmarshalling JAXB", e);

--- a/src/main/java/com/databasepreservation/modules/siard/in/read/ReadStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/in/read/ReadStrategy.java
@@ -4,7 +4,6 @@ import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 
 import java.io.InputStream;
-import java.nio.file.Path;
 
 /**
  * Defines the behaviour for reading data
@@ -38,6 +37,5 @@ public interface ReadStrategy {
          * @return Iterable of paths for files contained in the specified directory. The paths are suitable to be used in createInputStream. After use it should be closed.
          * @throws ModuleException
          */
-        CloseableIterable<String> getFilepathStream(SIARDArchiveContainer container)
-          throws ModuleException;
+        CloseableIterable<String> getFilepathStream(SIARDArchiveContainer container) throws ModuleException;
 }

--- a/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
@@ -81,6 +81,7 @@ import java.util.List;
 public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
         private static final String ENCODING = "UTF-8";
         private static final String METADATA_XSD_RESOURCE_PATH = "/schema/siard1-metadata.xsd";
+        private static final String METADATA_FILENAME = "metadata";
         private final Logger logger = Logger.getLogger(SIARD1MetadataExportStrategy.class);
         private final ContentPathExportStrategy contentPathStrategy;
         private final MetadataPathStrategy metadataPathStrategy;
@@ -123,7 +124,7 @@ public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
 
                         m.setSchema(xsdSchema);
                         OutputStream writer = writeStrategy
-                          .createOutputStream(container, metadataPathStrategy.getMetadataXmlFilePath());
+                          .createOutputStream(container, metadataPathStrategy.getXmlFilePath(METADATA_FILENAME));
                         m.marshal(xmlroot, writer);
                         writer.close();
                 } catch (JAXBException e) {
@@ -137,7 +138,7 @@ public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
           WriteStrategy writeStrategy) throws ModuleException {
                 // prepare to write
                 OutputStream out = writeStrategy
-                  .createOutputStream(container, metadataPathStrategy.getMetadataXsdFilePath());
+                  .createOutputStream(container, metadataPathStrategy.getXsdFilePath(METADATA_FILENAME));
                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
 
                 // prepare to read
@@ -148,7 +149,7 @@ public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
                         Files.copy(xsdSchema, out);
                 } catch (IOException e) {
                         throw new ModuleException(
-                          "Could not write " + metadataPathStrategy.getMetadataXsdFilePath() + " in container "
+                          "Could not write " + metadataPathStrategy.getXsdFilePath(METADATA_FILENAME) + " in container "
                             + container.toString(), e);
                 }
 

--- a/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
@@ -193,7 +193,8 @@ public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
                 if (StringUtils.isNotBlank(db.getDataOriginTimespan())) {
                         elem.setDataOriginTimespan(db.getDataOriginTimespan());
                 } else {
-                        throw new ModuleException("Error while exporting structure: data origin timestamp cannot be blank");
+                        throw new ModuleException(
+                          "Error while exporting structure: data origin timestamp cannot be blank");
                 }
 
                 if (StringUtils.isNotBlank(db.getProducerApplication())) {

--- a/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD2MetadataExportStrategy.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD2MetadataExportStrategy.java
@@ -81,6 +81,7 @@ import java.util.List;
 public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
         private static final String ENCODING = "UTF-8";
         private static final String METADATA_XSD_RESOURCE_PATH = "/schema/siard2-metadata.xsd";
+        private static final String METADATA_FILENAME = "metadata";
         private final Logger logger = Logger.getLogger(SIARD1MetadataExportStrategy.class);
         private final ContentPathExportStrategy contentPathStrategy;
         private final MetadataPathStrategy metadataPathStrategy;
@@ -123,7 +124,7 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
 
                         m.setSchema(xsdSchema);
                         OutputStream writer = writeStrategy
-                          .createOutputStream(container, metadataPathStrategy.getMetadataXmlFilePath());
+                          .createOutputStream(container, metadataPathStrategy.getXmlFilePath(METADATA_FILENAME));
                         m.marshal(xmlroot, writer);
                         writer.close();
                 } catch (JAXBException e) {
@@ -139,7 +140,7 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
           WriteStrategy writeStrategy) throws ModuleException {
                 // prepare to write
                 OutputStream out = writeStrategy
-                  .createOutputStream(container, metadataPathStrategy.getMetadataXsdFilePath());
+                  .createOutputStream(container, metadataPathStrategy.getXsdFilePath(METADATA_FILENAME));
                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
 
                 // prepare to read
@@ -150,7 +151,7 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
                         Files.copy(xsdSchema, out);
                 } catch (IOException e) {
                         throw new ModuleException(
-                          "Could not write " + metadataPathStrategy.getMetadataXsdFilePath() + " in container "
+                          "Could not write " + metadataPathStrategy.getXsdFilePath(METADATA_FILENAME) + " in container "
                             + container.toString(), e);
                 }
 

--- a/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
@@ -1,6 +1,6 @@
 package com.databasepreservation.modules.siard.out.output;
 
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.common.path.MetadataPathStrategy;
 import com.databasepreservation.modules.siard.common.path.SIARD1MetadataPathStrategy;
@@ -44,7 +44,7 @@ public class SIARD1ExportModule {
                   true);
         }
 
-        public DatabaseHandler getDatabaseHandler() {
+        public DatabaseExportModule getDatabaseHandler() {
                 return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy);
         }
 }

--- a/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
@@ -40,7 +40,8 @@ public class SIARD2ExportModule {
 
                 metadataStrategy = new SIARD2MetadataExportStrategy(metadataPathStrategy, contentPathStrategy);
                 //TODO: change prettyXML from 'true' to a module argument
-                contentStrategy = new SIARD2ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer,true);
+                contentStrategy = new SIARD2ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer,
+                  true);
         }
 
         public DatabaseExportModule getDatabaseHandler() {

--- a/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
@@ -1,6 +1,6 @@
 package com.databasepreservation.modules.siard.out.output;
 
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.common.path.MetadataPathStrategy;
 import com.databasepreservation.modules.siard.common.path.SIARD2MetadataPathStrategy;
@@ -43,7 +43,7 @@ public class SIARD2ExportModule {
                 contentStrategy = new SIARD2ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer,true);
         }
 
-        public DatabaseHandler getDatabaseHandler() {
+        public DatabaseExportModule getDatabaseHandler() {
                 return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy);
         }
 }

--- a/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDExportDefault.java
+++ b/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDExportDefault.java
@@ -7,7 +7,7 @@ import com.databasepreservation.model.exception.UnknownTypeException;
 import com.databasepreservation.model.structure.DatabaseStructure;
 import com.databasepreservation.model.structure.SchemaStructure;
 import com.databasepreservation.model.structure.TableStructure;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.out.content.ContentExportStrategy;
 import com.databasepreservation.modules.siard.out.metadata.MetadataExportStrategy;
@@ -18,7 +18,7 @@ import java.util.Set;
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
-public class SIARDExportDefault implements DatabaseHandler {
+public class SIARDExportDefault implements DatabaseExportModule {
         private final SIARDArchiveContainer mainContainer;
         private final WriteStrategy writeStrategy;
         private final MetadataExportStrategy metadataStrategy;

--- a/src/main/java/com/databasepreservation/modules/sqlFile/out/SQLFileExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/sqlFile/out/SQLFileExportModule.java
@@ -18,7 +18,7 @@ import com.databasepreservation.model.structure.SchemaStructure;
 import com.databasepreservation.model.structure.TableStructure;
 import com.databasepreservation.model.structure.type.SimpleTypeNumericApproximate;
 import com.databasepreservation.model.structure.type.SimpleTypeNumericExact;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.SQLHelper;
 import com.databasepreservation.modules.SQLHelper.CellSQLHandler;
 import org.apache.log4j.Logger;
@@ -41,7 +41,7 @@ import java.util.Set;
 /**
  * @author Luis Faria
  */
-public class SQLFileExportModule implements DatabaseHandler {
+public class SQLFileExportModule implements DatabaseExportModule {
         private static final Logger logger = Logger.getLogger(SQLFileExportModule.class);
 
         protected File sqlFile;

--- a/src/main/java/com/databasepreservation/modules/sqlFile/out/SQLFileExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/sqlFile/out/SQLFileExportModule.java
@@ -103,16 +103,16 @@ public class SQLFileExportModule implements DatabaseExportModule {
                 // BufferedInputStream buffin = new BufferedInputStream(in);
                 // BufferedOutputStream buffout = new BufferedOutputStream(out);
 
-                out.write("E'" .getBytes());
+                out.write("E'".getBytes());
 
                 int ibyte = in.read();
                 while (ibyte != -1) {
                         switch (ibyte) {
                                 case '\'':
-                                        out.write("''" .getBytes());
+                                        out.write("''".getBytes());
                                         break;
                                 case '\\':
-                                        out.write("\\\\" .getBytes());
+                                        out.write("\\\\".getBytes());
                                         break;
                                 default:
                                         if (ibyte > 0 && ibyte < 31 || ibyte > 127 && ibyte <= 255) {
@@ -126,7 +126,7 @@ public class SQLFileExportModule implements DatabaseExportModule {
                         ibyte = in.read();
                 }
 
-                out.write("'" .getBytes());
+                out.write("'".getBytes());
         }
 
         /**
@@ -147,19 +147,19 @@ public class SQLFileExportModule implements DatabaseExportModule {
                 BufferedInputStream bin = new BufferedInputStream(in);
                 BufferedOutputStream bout = new BufferedOutputStream(out);
 
-                bout.write("E'" .getBytes());
+                bout.write("E'".getBytes());
                 int ibyte = bin.read();
                 while (ibyte != -1) {
 
                         switch (ibyte) {
                                 case 0:
-                                        bout.write("\\\\000" .getBytes());
+                                        bout.write("\\\\000".getBytes());
                                         break;
                                 case '\'':
-                                        bout.write("''''" .getBytes());
+                                        bout.write("''''".getBytes());
                                         break;
                                 case '\\':
-                                        bout.write("\\\\\\\\" .getBytes());
+                                        bout.write("\\\\\\\\".getBytes());
                                         break;
                                 default:
                                         if (ibyte > 0 && ibyte < 31 || ibyte > 127 && ibyte <= 255) {
@@ -172,7 +172,7 @@ public class SQLFileExportModule implements DatabaseExportModule {
 
                         ibyte = bin.read();
                 }
-                bout.write("'::bytea" .getBytes());
+                bout.write("'::bytea".getBytes());
                 bout.flush();
 
         }
@@ -256,7 +256,7 @@ public class SQLFileExportModule implements DatabaseExportModule {
                                         if (cell instanceof SimpleCell) {
                                                 SimpleCell simple = (SimpleCell) cell;
                                                 if (simple.getSimpledata() == null) {
-                                                        ret = "NULL" .getBytes();
+                                                        ret = "NULL".getBytes();
                                                 } else if (column.getType() instanceof SimpleTypeNumericExact || column
                                                   .getType() instanceof SimpleTypeNumericApproximate) {
                                                         ret = simple.getSimpledata().getBytes();
@@ -289,7 +289,7 @@ public class SQLFileExportModule implements DatabaseExportModule {
                         });
                         byte[] rowSQLCollon = new byte[rowSQL.length + 2];
                         System.arraycopy(rowSQL, 0, rowSQLCollon, 0, rowSQL.length);
-                        System.arraycopy(";\n" .getBytes(), 0, rowSQLCollon, rowSQL.length, 2);
+                        System.arraycopy(";\n".getBytes(), 0, rowSQLCollon, rowSQL.length, 2);
                         try {
                                 sqlOutput.write(rowSQLCollon);
                         } catch (IOException e) {

--- a/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
@@ -1,0 +1,139 @@
+package com.databasepreservation.modules.sqlServer;
+
+import com.databasepreservation.cli.Parameter;
+import com.databasepreservation.cli.ParameterGroup;
+import com.databasepreservation.cli.Parameters;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import com.databasepreservation.modules.sqlServer.in.SQLServerJDBCImportModule;
+import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
+        private static final Parameter serverName = new Parameter().shortName("s").longName("server-name")
+          .description("the name (host name) of the server").hasArgument(true).required(true);
+
+        private static final Parameter database = new Parameter().shortName("db").longName("database")
+          .description("the name of the database we'll be accessing").hasArgument(true).required(true);
+
+        private static final Parameter username = new Parameter().shortName("u").longName("username")
+          .description("the name of the user to use in the connection").hasArgument(true).required(true);
+
+        private static final Parameter password = new Parameter().shortName("p").longName("password")
+          .description("the password of the user to use in the connection").hasArgument(true).required(true);
+
+        private static final Parameter useIntegratedLogin = new Parameter().shortName("l")
+          .longName("use-integrated-login").description("use windows login; by default the SQL Server login is used")
+          .hasArgument(false).required(false).valueIfNotSet("false").valueIfSet("true");
+
+        private static final Parameter dontEncrypt = new Parameter().shortName("ne").longName("do-not-encrypt")
+          .description("use to turn off encryption in the connection").hasArgument(false).required(false)
+          .valueIfNotSet("false").valueIfSet("true");
+
+        private static final Parameter instanceName = new Parameter().shortName("in").longName("instance-name")
+          .description("").hasArgument(true).required(false);
+
+        private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
+          .description("the port number of the server instance, default is 1433").hasArgument(true).required(false)
+          .valueIfNotSet("1433");
+
+        private static final ParameterGroup instanceName_portNumber = new ParameterGroup(false, instanceName,
+          portNumber);
+
+        @Override public boolean producesImportModules() {
+                return true;
+        }
+
+        @Override public boolean producesExportModules() {
+                return true;
+        }
+
+        @Override public String getModuleName() {
+                return "SQLServerJDBC";
+        }
+
+        @Override public Parameters getImportModuleParameters() {
+                return new Parameters(
+                  Arrays.asList(serverName, database, username, password, useIntegratedLogin, dontEncrypt),
+                  Arrays.asList(instanceName_portNumber));
+        }
+
+        @Override public Parameters getExportModuleParameters() {
+                return new Parameters(
+                  Arrays.asList(serverName, database, username, password, useIntegratedLogin, dontEncrypt),
+                  Arrays.asList(instanceName_portNumber));
+        }
+
+        @Override public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters) {
+                // String values
+                String pServerName = parameters.get(serverName);
+                String pDatabase = parameters.get(database);
+                String pUsername = parameters.get(username);
+                String pPassword = parameters.get(password);
+
+                // boolean
+                boolean pUseIntegratedLogin = Boolean.parseBoolean(parameters.get(useIntegratedLogin));
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+
+                // optional
+                Integer pPortNumber = null;
+                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
+                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                }
+                String pInstanceName = null;
+                if (StringUtils.isNotBlank(parameters.get(instanceName))) {
+                        pInstanceName = parameters.get(instanceName);
+                }
+
+                if (pPortNumber != null) {
+                        return new SQLServerJDBCImportModule(pServerName, pPortNumber, pDatabase, pUsername, pPassword,
+                          pUseIntegratedLogin, pEncrypt);
+                } else if (pInstanceName != null) {
+                        return new SQLServerJDBCImportModule(pServerName, pInstanceName, pDatabase, pUsername,
+                          pPassword, pUseIntegratedLogin, pEncrypt);
+                } else {
+                        return new SQLServerJDBCImportModule(pServerName, pDatabase, pUsername, pPassword,
+                          pUseIntegratedLogin, pEncrypt);
+                }
+        }
+
+        @Override public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters) {
+                // String values
+                String pServerName = parameters.get(serverName);
+                String pDatabase = parameters.get(database);
+                String pUsername = parameters.get(username);
+                String pPassword = parameters.get(password);
+
+                // boolean
+                boolean pUseIntegratedLogin = Boolean.parseBoolean(parameters.get(useIntegratedLogin));
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+
+                // optional
+                Integer pPortNumber = null;
+                if (StringUtils.isNotBlank(parameters.get(portNumber))) {
+                        pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                }
+                String pInstanceName = null;
+                if (StringUtils.isNotBlank(parameters.get(instanceName))) {
+                        pInstanceName = parameters.get(instanceName);
+                }
+
+                if (pPortNumber != null) {
+                        return new SQLServerJDBCExportModule(pServerName, pPortNumber, pDatabase, pUsername, pPassword,
+                          pUseIntegratedLogin, pEncrypt);
+                } else if (pInstanceName != null) {
+                        return new SQLServerJDBCExportModule(pServerName, pInstanceName, pDatabase, pUsername,
+                          pPassword, pUseIntegratedLogin, pEncrypt);
+                } else {
+                        return new SQLServerJDBCExportModule(pServerName, pDatabase, pUsername, pPassword,
+                          pUseIntegratedLogin, pEncrypt);
+                }
+        }
+}

--- a/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
@@ -38,7 +38,7 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
           .longName("use-integrated-login").description("use windows login; by default the SQL Server login is used")
           .hasArgument(false).required(false).valueIfNotSet("false").valueIfSet("true");
 
-        private static final Parameter dontEncrypt = new Parameter().shortName("ne").longName("do-not-encrypt")
+        private static final Parameter disableEncryption = new Parameter().shortName("de").longName("disable-encryption")
           .description("use to turn off encryption in the connection").hasArgument(false).required(false)
           .valueIfNotSet("false").valueIfSet("true");
 
@@ -71,7 +71,7 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
                 parameterHashMap.put(username.longName(), username);
                 parameterHashMap.put(password.longName(), password);
                 parameterHashMap.put(useIntegratedLogin.longName(), useIntegratedLogin);
-                parameterHashMap.put(dontEncrypt.longName(), dontEncrypt);
+                parameterHashMap.put(disableEncryption.longName(), disableEncryption);
                 parameterHashMap.put(instanceName.longName(), instanceName);
                 parameterHashMap.put(portNumber.longName(), portNumber);
                 return parameterHashMap;
@@ -79,13 +79,13 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
 
         @Override public Parameters getImportModuleParameters() {
                 return new Parameters(
-                  Arrays.asList(serverName, database, username, password, useIntegratedLogin, dontEncrypt),
+                  Arrays.asList(serverName, database, username, password, useIntegratedLogin, disableEncryption),
                   Arrays.asList(instanceName_portNumber));
         }
 
         @Override public Parameters getExportModuleParameters() {
                 return new Parameters(
-                  Arrays.asList(serverName, database, username, password, useIntegratedLogin, dontEncrypt),
+                  Arrays.asList(serverName, database, username, password, useIntegratedLogin, disableEncryption),
                   Arrays.asList(instanceName_portNumber));
         }
 
@@ -98,7 +98,7 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
 
                 // boolean
                 boolean pUseIntegratedLogin = Boolean.parseBoolean(parameters.get(useIntegratedLogin));
-                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(disableEncryption));
 
                 // optional
                 Integer pPortNumber = null;
@@ -131,7 +131,7 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
 
                 // boolean
                 boolean pUseIntegratedLogin = Boolean.parseBoolean(parameters.get(useIntegratedLogin));
-                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(dontEncrypt));
+                boolean pEncrypt = !Boolean.parseBoolean(parameters.get(disableEncryption));
 
                 // optional
                 Integer pPortNumber = null;

--- a/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
@@ -18,16 +18,16 @@ import java.util.Map;
  */
 public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
         private static final Parameter serverName = new Parameter().shortName("s").longName("server-name")
-          .description("the name (host name) of the server").hasArgument(true).required(true);
+          .description("the name (host name) of the server").hasArgument(true).setOptionalArgument(false).required(true);
 
         private static final Parameter database = new Parameter().shortName("db").longName("database")
-          .description("the name of the database we'll be accessing").hasArgument(true).required(true);
+          .description("the name of the database we'll be accessing").hasArgument(true).setOptionalArgument(false).required(true);
 
         private static final Parameter username = new Parameter().shortName("u").longName("username")
-          .description("the name of the user to use in the connection").hasArgument(true).required(true);
+          .description("the name of the user to use in the connection").hasArgument(true).setOptionalArgument(false).required(true);
 
         private static final Parameter password = new Parameter().shortName("p").longName("password")
-          .description("the password of the user to use in the connection").hasArgument(true).required(true);
+          .description("the password of the user to use in the connection").hasArgument(true).setOptionalArgument(false).required(true);
 
         private static final Parameter useIntegratedLogin = new Parameter().shortName("l")
           .longName("use-integrated-login").description("use windows login; by default the SQL Server login is used")
@@ -38,10 +38,10 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
           .valueIfNotSet("false").valueIfSet("true");
 
         private static final Parameter instanceName = new Parameter().shortName("in").longName("instance-name")
-          .description("").hasArgument(true).required(false);
+          .description("").hasArgument(true).setOptionalArgument(false).required(false);
 
         private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
-          .description("the port number of the server instance, default is 1433").hasArgument(true).required(false)
+          .description("the port number of the server instance, default is 1433").hasArgument(true).setOptionalArgument(false).required(false)
           .valueIfNotSet("1433");
 
         private static final ParameterGroup instanceName_portNumber = new ParameterGroup(false, instanceName,

--- a/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
@@ -38,9 +38,9 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
           .longName("use-integrated-login").description("use windows login; by default the SQL Server login is used")
           .hasArgument(false).required(false).valueIfNotSet("false").valueIfSet("true");
 
-        private static final Parameter disableEncryption = new Parameter().shortName("de").longName("disable-encryption")
-          .description("use to turn off encryption in the connection").hasArgument(false).required(false)
-          .valueIfNotSet("false").valueIfSet("true");
+        private static final Parameter disableEncryption = new Parameter().shortName("de")
+          .longName("disable-encryption").description("use to turn off encryption in the connection").hasArgument(false)
+          .required(false).valueIfNotSet("false").valueIfSet("true");
 
         private static final Parameter instanceName = new Parameter().shortName("in").longName("instance-name")
           .description("the name of the instance").hasArgument(true).setOptionalArgument(false).required(false);

--- a/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
@@ -11,6 +11,7 @@ import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -18,16 +19,20 @@ import java.util.Map;
  */
 public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
         private static final Parameter serverName = new Parameter().shortName("s").longName("server-name")
-          .description("the name (host name) of the server").hasArgument(true).setOptionalArgument(false).required(true);
+          .description("the name (host name) of the server").hasArgument(true).setOptionalArgument(false)
+          .required(true);
 
         private static final Parameter database = new Parameter().shortName("db").longName("database")
-          .description("the name of the database we'll be accessing").hasArgument(true).setOptionalArgument(false).required(true);
+          .description("the name of the database we'll be accessing").hasArgument(true).setOptionalArgument(false)
+          .required(true);
 
         private static final Parameter username = new Parameter().shortName("u").longName("username")
-          .description("the name of the user to use in the connection").hasArgument(true).setOptionalArgument(false).required(true);
+          .description("the name of the user to use in the connection").hasArgument(true).setOptionalArgument(false)
+          .required(true);
 
         private static final Parameter password = new Parameter().shortName("p").longName("password")
-          .description("the password of the user to use in the connection").hasArgument(true).setOptionalArgument(false).required(true);
+          .description("the password of the user to use in the connection").hasArgument(true).setOptionalArgument(false)
+          .required(true);
 
         private static final Parameter useIntegratedLogin = new Parameter().shortName("l")
           .longName("use-integrated-login").description("use windows login; by default the SQL Server login is used")
@@ -41,8 +46,8 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
           .description("").hasArgument(true).setOptionalArgument(false).required(false);
 
         private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
-          .description("the port number of the server instance, default is 1433").hasArgument(true).setOptionalArgument(false).required(false)
-          .valueIfNotSet("1433");
+          .description("the port number of the server instance, default is 1433").hasArgument(true)
+          .setOptionalArgument(false).required(false).valueIfNotSet("1433");
 
         private static final ParameterGroup instanceName_portNumber = new ParameterGroup(false, instanceName,
           portNumber);
@@ -57,6 +62,19 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
 
         @Override public String getModuleName() {
                 return "SQLServerJDBC";
+        }
+
+        @Override public Map<String, Parameter> getAllParameters() {
+                HashMap<String, Parameter> parameterHashMap = new HashMap<String, Parameter>();
+                parameterHashMap.put(serverName.longName(), serverName);
+                parameterHashMap.put(database.longName(), database);
+                parameterHashMap.put(username.longName(), username);
+                parameterHashMap.put(password.longName(), password);
+                parameterHashMap.put(useIntegratedLogin.longName(), useIntegratedLogin);
+                parameterHashMap.put(dontEncrypt.longName(), dontEncrypt);
+                parameterHashMap.put(instanceName.longName(), instanceName);
+                parameterHashMap.put(portNumber.longName(), portNumber);
+                return parameterHashMap;
         }
 
         @Override public Parameters getImportModuleParameters() {

--- a/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/SQLServerJDBCModuleFactory.java
@@ -43,7 +43,7 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
           .valueIfNotSet("false").valueIfSet("true");
 
         private static final Parameter instanceName = new Parameter().shortName("in").longName("instance-name")
-          .description("").hasArgument(true).setOptionalArgument(false).required(false);
+          .description("the name of the instance").hasArgument(true).setOptionalArgument(false).required(false);
 
         private static final Parameter portNumber = new Parameter().shortName("pn").longName("port-number")
           .description("the port number of the server instance, default is 1433").hasArgument(true)
@@ -137,20 +137,19 @@ public class SQLServerJDBCModuleFactory implements DatabaseModuleFactory {
                 Integer pPortNumber = null;
                 if (StringUtils.isNotBlank(parameters.get(portNumber))) {
                         pPortNumber = Integer.parseInt(parameters.get(portNumber));
+                } else {
+                        pPortNumber = Integer.parseInt(portNumber.valueIfNotSet());
                 }
                 String pInstanceName = null;
                 if (StringUtils.isNotBlank(parameters.get(instanceName))) {
                         pInstanceName = parameters.get(instanceName);
                 }
 
-                if (pPortNumber != null) {
-                        return new SQLServerJDBCExportModule(pServerName, pPortNumber, pDatabase, pUsername, pPassword,
-                          pUseIntegratedLogin, pEncrypt);
-                } else if (pInstanceName != null) {
+                if (pInstanceName != null) {
                         return new SQLServerJDBCExportModule(pServerName, pInstanceName, pDatabase, pUsername,
                           pPassword, pUseIntegratedLogin, pEncrypt);
                 } else {
-                        return new SQLServerJDBCExportModule(pServerName, pDatabase, pUsername, pPassword,
+                        return new SQLServerJDBCExportModule(pServerName, pPortNumber, pDatabase, pUsername, pPassword,
                           pUseIntegratedLogin, pEncrypt);
                 }
         }

--- a/src/main/java/com/databasepreservation/modules/sqlServer/out/SQLServerJDBCExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/sqlServer/out/SQLServerJDBCExportModule.java
@@ -23,7 +23,6 @@ import java.sql.Types;
  * @author Luis Faria
  */
 public class SQLServerJDBCExportModule extends JDBCExportModule {
-
         private final Logger logger = Logger.getLogger(SQLServerJDBCExportModule.class);
 
         /**

--- a/src/main/resources/config/cli.properties
+++ b/src/main/resources/config/cli.properties
@@ -1,0 +1,1 @@
+modules:com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory

--- a/src/main/resources/config/cli.properties
+++ b/src/main/resources/config/cli.properties
@@ -1,1 +1,0 @@
-modules:com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/MySqlTest.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/MySqlTest.java
@@ -59,31 +59,37 @@ import java.util.Set;
                 ArrayList<Object[]> tests = new ArrayList<Object[]>();
 
                 //TODO: test NULL
-                tests.add(new String[]{singleTypeAndValue, "TINYINT(10)", "1"}); // the number inside parentheses is the display width, does not affect datatype size and is ignored
-                tests.add(new String[]{singleTypeAndValue, "TINYINT", "1"});
+                tests.add(new String[] {singleTypeAndValue, "TINYINT(10)",
+                  "1"}); // the number inside parentheses is the display width, does not affect datatype size and is ignored
+                tests.add(new String[] {singleTypeAndValue, "TINYINT", "1"});
                 tests.add(new String[] {singleTypeAndValue, "SMALLINT", "123"});
                 tests.add(new String[] {singleTypeAndValue, "MEDIUMINT(10)", "123"});
                 tests.add(new String[] {singleTypeAndValue, "MEDIUMINT", "123"});
                 tests.add(new String[] {singleTypeAndValue, "INT", "123"});
-                tests.add(new String[]{singleTypeAndValue, "BIGINT(30)", "-9223372036854775808"});
-                tests.add(new String[]{singleTypeAndValue, "BIGINT", "9223372036854775807"});
+                tests.add(new String[] {singleTypeAndValue, "BIGINT(30)", "-9223372036854775808"});
+                tests.add(new String[] {singleTypeAndValue, "BIGINT", "9223372036854775807"});
                 tests.add(new String[] {singleTypeAndValue, "DECIMAL", "123"});
                 tests.add(new String[] {singleTypeAndValue, "NUMERIC", "123"});
-                tests.add(new String[]{singleTypeAndValue, "FLOAT", "12345.123"});
-                tests.add(new String[]{singleTypeAndValue, "FLOAT", "123456789012"});
-                tests.add(new String[]{singleTypeAndValue, "FLOAT(9)", "12345.123"}); //in mysql, this creates a float(12,0)
-                tests.add(new String[]{singleTypeAndValue, "FLOAT(12)", "12345.123"}); //in mysql, this creates a float(12,0)
-                tests.add(new String[]{singleTypeAndValue, "FLOAT(12,0)", "12345.123"}); //in mysql, this creates a float(12,0)
-                tests.add(new String[]{singleTypeAndValue, "FLOAT(53)", "12345.123"}); //in mysql, this creates a double(22,0)
-                tests.add(new String[]{singleTypeAndValue, "FLOAT(8,3)", "12345.123"}); //in mysql, this creates a float(8,3)
-                tests.add(new String[]{singleTypeAndValue, "DOUBLE", "1234567890.12345"});
-                tests.add(new String[]{singleTypeAndValue, "DOUBLE(22,0)", "1234567890.12345"});
-                tests.add(new String[]{singleTypeAndValue, "DOUBLE(10,2)", "1234567890.12345"});
+                tests.add(new String[] {singleTypeAndValue, "FLOAT", "12345.123"});
+                tests.add(new String[] {singleTypeAndValue, "FLOAT", "123456789012"});
+                tests.add(
+                  new String[] {singleTypeAndValue, "FLOAT(9)", "12345.123"}); //in mysql, this creates a float(12,0)
+                tests.add(
+                  new String[] {singleTypeAndValue, "FLOAT(12)", "12345.123"}); //in mysql, this creates a float(12,0)
+                tests.add(
+                  new String[] {singleTypeAndValue, "FLOAT(12,0)", "12345.123"}); //in mysql, this creates a float(12,0)
+                tests.add(
+                  new String[] {singleTypeAndValue, "FLOAT(53)", "12345.123"}); //in mysql, this creates a double(22,0)
+                tests.add(
+                  new String[] {singleTypeAndValue, "FLOAT(8,3)", "12345.123"}); //in mysql, this creates a float(8,3)
+                tests.add(new String[] {singleTypeAndValue, "DOUBLE", "1234567890.12345"});
+                tests.add(new String[] {singleTypeAndValue, "DOUBLE(22,0)", "1234567890.12345"});
+                tests.add(new String[] {singleTypeAndValue, "DOUBLE(10,2)", "1234567890.12345"});
                 tests.add(new String[] {singleTypeAndValue, "BIT(1)", "b'1'"});
                 tests.add(new String[] {singleTypeAndValue, "BIT", "b'1'"});
                 tests.add(new String[] {singleTypeAndValue, "BIT(1)", "b'0'"});
                 tests.add(new String[] {singleTypeAndValue, "BIT(5)", "b'11111'"});
-                tests.add(new String[]{singleTypeAndValue, "BIT(64)", "b'" + StringUtils.repeat("1001", 16) + "'"});
+                tests.add(new String[] {singleTypeAndValue, "BIT(64)", "b'" + StringUtils.repeat("1001", 16) + "'"});
                 tests.add(new String[] {singleTypeAndValue, "DATE", "'9999-12-31'"});
                 tests.add(new String[] {singleTypeAndValue, "DATE", "'2015-01-01'"});
                 tests.add(new String[] {singleTypeAndValue, "DATETIME", "'9999-12-31 23:59:59.999999'"});
@@ -91,28 +97,32 @@ import java.util.Set;
                 //tests.add(new String[]{singleTypeAndValue, "YEAR(2)", "'15'"}); // difficult to make the test pass, because the value is changed from 15 to 2015
                 //tests.add(new String[]{singleTypeAndValue, "YEAR(2)", "5"}); // difficult to make the test pass, because the value is changed from 15 to 2015
                 //tests.add(new String[]{singleTypeAndValue, "YEAR(2)", "2015"}); // difficult to make the test pass, because the value is changed from 15 to 2015
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "2015"});
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "'0'"});// becomes 2000, zero is not allowed as number
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "1"}); // becomes 2001
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "'1'"});
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "99"}); // becomes 1999
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "'99'"});
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "70"}); // becomes 1970
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "'70'"});
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "69"}); // becomes 2069
-                tests.add(new String[]{singleTypeAndValue, "YEAR(4)", "'69'"});
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "2015"});
+                tests.add(
+                  new String[] {singleTypeAndValue, "YEAR(4)", "'0'"});// becomes 2000, zero is not allowed as number
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "1"}); // becomes 2001
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "'1'"});
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "99"}); // becomes 1999
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "'99'"});
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "70"}); // becomes 1970
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "'70'"});
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "69"}); // becomes 2069
+                tests.add(new String[] {singleTypeAndValue, "YEAR(4)", "'69'"});
                 //TODO: tests character sets and collations
-                tests.add(new String[]{singleTypeAndValue, "CHAR(0)", "NULL"});
+                tests.add(new String[] {singleTypeAndValue, "CHAR(0)", "NULL"});
                 //tests.add(new String[]{singleTypeAndValue, "CHAR(0) NOT NULL", "''"}); //fixme: for empty strings, the value becomes null
-                tests.add(new String[]{singleTypeAndValue, "CHAR(3)", "'abc'"});
-                tests.add(new String[]{singleTypeAndValue, "CHAR(253)", "NULL"});
-                tests.add(new String[]{singleTypeAndValue, "CHAR(253) NOT NULL", "'" + StringUtils.repeat("asdf", 64) + "'"});
-                tests.add(new String[]{singleTypeAndValue, "CHAR(255)", "NULL"});
-                tests.add(new String[]{singleTypeAndValue, "CHAR(255) NOT NULL", "'" + StringUtils.repeat("asdf", 64) + "'"});
+                tests.add(new String[] {singleTypeAndValue, "CHAR(3)", "'abc'"});
+                tests.add(new String[] {singleTypeAndValue, "CHAR(253)", "NULL"});
+                tests.add(
+                  new String[] {singleTypeAndValue, "CHAR(253) NOT NULL", "'" + StringUtils.repeat("asdf", 64) + "'"});
+                tests.add(new String[] {singleTypeAndValue, "CHAR(255)", "NULL"});
+                tests.add(
+                  new String[] {singleTypeAndValue, "CHAR(255) NOT NULL", "'" + StringUtils.repeat("asdf", 64) + "'"});
                 //tests.add(new String[]{singleTypeAndValue, "CHAR(255) NOT NULL", "''"}); //fixme: similar to CHAR(0) NOT NULL
                 //tests.add(new String[] {singleTypeAndValue, "VARCHAR(10) NOT NULL", "''"}); //fixme: similar to CHAR(0) NOT NULL
                 tests.add(new String[] {singleTypeAndValue, "VARCHAR(1024)", "NULL"});
-                tests.add(new String[] {singleTypeAndValue, "VARCHAR(255)", "'" + StringUtils.repeat("asdf", 64) + "'"});
+                tests
+                  .add(new String[] {singleTypeAndValue, "VARCHAR(255)", "'" + StringUtils.repeat("asdf", 64) + "'"});
                 //tests.add(new String[] {singleTypeAndValue, "VARCHAR(4098)", "'" + StringUtils.repeat("asdfqwertyuighjk", 4096) + "'"}); //fixme: in siard, small strings are strings, longer strings are clobs
                 //TODO: more relevant tests for the types below
                 //tests.add(new String[]{singleTypeAndValue, "BINARY(255)", "NULL"});

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/MySqlTest.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/MySqlTest.java
@@ -43,10 +43,16 @@ import java.util.Set;
                     db_source), String
                   .format("mysqldump -v --user=\"%s\" --password=\"%s\" %s --compact", db_tmp_username, db_tmp_password,
                     db_target),
-                  new String[] {"-i", "MySQLJDBC", "localhost", db_source, db_tmp_username, db_tmp_password, "-o",
-                    "SIARD1", Roundtrip.TMP_FILE_SIARD_VAR, "store"},
-                  new String[] {"-i", "SIARD1", Roundtrip.TMP_FILE_SIARD_VAR, "-o", "MySQLJDBC", "localhost", db_target,
-                    db_tmp_username, db_tmp_password}, new MySqlDumpDiffExpectations(), null, null);
+
+                  new String[] {"--import=MySQLJDBC", "--ihostname=localhost", "--idatabase", db_source, "--iusername",
+                    db_tmp_username, "--ipassword", db_tmp_password, "--export=SIARD1", "--ecompress", "--efile",
+                    Roundtrip.TMP_FILE_SIARD_VAR},
+
+                  new String[] {"--import=SIARD1", "--ifile", Roundtrip.TMP_FILE_SIARD_VAR, "--export=MySQLJDBC",
+                    "--ehostname=localhost", "--edatabase", db_target, "--eusername", db_tmp_username, "--epassword",
+                    db_tmp_password},
+
+                  new MySqlDumpDiffExpectations(), null, null);
         }
 
         @Test(description = "MySql server is available and accessible") public void testConnection()

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/PostgreSqlTest.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/PostgreSqlTest.java
@@ -55,12 +55,12 @@ import java.util.Set;
                   "pg_dump --format plain --no-owner --no-privileges --column-inserts --no-security-labels --no-tablespaces",
 
                   new String[] {"--import=PostgreSQLJDBC", "--ihostname=localhost", "--idatabase", db_source,
-                    "--iusername", db_tmp_username, "--ipassword", db_tmp_password, "--ido-not-encrypt",
+                    "--iusername", db_tmp_username, "--ipassword", db_tmp_password, "--idisable-encryption",
                     "--export=SIARD1", "--efile", Roundtrip.TMP_FILE_SIARD_VAR},
 
                   new String[] {"--import=SIARD1", "--ifile", Roundtrip.TMP_FILE_SIARD_VAR, "--export=PostgreSQLJDBC",
                     "--ehostname=localhost", "--edatabase", db_target, "--eusername", db_tmp_username, "--epassword",
-                    db_tmp_password, "--edo-not-encrypt"}, new PostgreSqlDumpDiffExpectations(), env_var_source,
+                    db_tmp_password, "--edisable-encryption"}, new PostgreSqlDumpDiffExpectations(), env_var_source,
                   env_var_target);
         }
 

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/PostgreSqlTest.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/PostgreSqlTest.java
@@ -53,11 +53,15 @@ import java.util.Set;
                   db_tmp_username), "psql -q",
                   "pg_dump --format plain --no-owner --no-privileges --column-inserts --no-security-labels --no-tablespaces",
                   "pg_dump --format plain --no-owner --no-privileges --column-inserts --no-security-labels --no-tablespaces",
-                  new String[] {"-i", "PostgreSQLJDBC", "localhost", db_source, db_tmp_username, db_tmp_password,
-                    "false", "-o", "SIARD1", Roundtrip.TMP_FILE_SIARD_VAR, "store"},
-                  new String[] {"-i", "SIARD1", Roundtrip.TMP_FILE_SIARD_VAR, "-o", "PostgreSQLJDBC", "localhost",
-                    db_target, db_tmp_username, db_tmp_password, "false"}, new PostgreSqlDumpDiffExpectations(),
-                  env_var_source, env_var_target);
+
+                  new String[] {"--import=PostgreSQLJDBC", "--ihostname=localhost", "--idatabase", db_source,
+                    "--iusername", db_tmp_username, "--ipassword", db_tmp_password, "--ido-not-encrypt",
+                    "--export=SIARD1", "--efile", Roundtrip.TMP_FILE_SIARD_VAR},
+
+                  new String[] {"--import=SIARD1", "--ifile", Roundtrip.TMP_FILE_SIARD_VAR, "--export=PostgreSQLJDBC",
+                    "--ehostname=localhost", "--edatabase", db_target, "--eusername", db_tmp_username, "--epassword",
+                    db_tmp_password, "--edo-not-encrypt"}, new PostgreSqlDumpDiffExpectations(), env_var_source,
+                  env_var_target);
         }
 
         @Test(description = "PostgreSql server is available and accessible") public void testConnection()

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/Roundtrip.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/Roundtrip.java
@@ -156,7 +156,7 @@ public class Roundtrip {
                                 // this asserts that both dumps represent the same information
                                 try {
                                         dumpDiffExpectations.dumpsRepresentTheSameInformation(dump_source, dump_target);
-                                }catch (AssertionError e){
+                                } catch (AssertionError e) {
                                         Files.deleteIfExists(dump_source);
                                         Files.deleteIfExists(dump_target);
                                         FileUtils.deleteDirectoryRecursive(dumpsDir);

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/differences/DumpDiffExpectations.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/differences/DumpDiffExpectations.java
@@ -14,10 +14,10 @@ import static org.hamcrest.Matchers.is;
 /**
  * Roundtrip testing generates a textual database dump before converting the data to SIARD format and
  * after importing it from the SIARD archive back to the database.
- *
+ * <p>
  * This interface provides an API to check if everything that should differ between the dumps is really
  * different and that the rest of the text did not change.
- *
+ * <p>
  * The implementations should be specific to some DBMS.
  *
  * @author Bruno Ferreira <bferreira@keep.pt>
@@ -27,6 +27,7 @@ public abstract class DumpDiffExpectations {
 
         /**
          * Creates a modified version of the source database dump that should equal to the target database dump
+         *
          * @param source the source database dump
          * @return the expected target database dump
          */

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/differences/MySqlDumpDiffExpectations.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/differences/MySqlDumpDiffExpectations.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 /**
  * MySQL specific implementation to convert the source database dump to an expected version of the database dump
+ *
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class MySqlDumpDiffExpectations extends DumpDiffExpectations {
@@ -39,13 +40,13 @@ public class MySqlDumpDiffExpectations extends DumpDiffExpectations {
 
                 // float(N,M) -> decimal(N,M)
                 //   where N != 12 and M != 0 (ensured by the order of the patterns in the ArrayList)
-                directReplacements
-                  .add(new ImmutablePair<Pattern, String>(Pattern.compile("(?<=\\W)float\\((\\d+),(\\d+)\\)(?=\\W)"),
+                directReplacements.add(
+                  new ImmutablePair<Pattern, String>(Pattern.compile("(?<=\\W)float\\((\\d+),(\\d+)\\)(?=\\W)"),
                     "decimal($1,$2)"));
 
                 // double(22,0) -> float
-                directReplacements
-                  .add(new ImmutablePair<Pattern, String>(Pattern.compile("(?<=\\W)double\\(22,0\\)(?=\\W)"), "double"));
+                directReplacements.add(
+                  new ImmutablePair<Pattern, String>(Pattern.compile("(?<=\\W)double\\(22,0\\)(?=\\W)"), "double"));
 
                 // double(N,M) -> decimal(N,M)
                 //   where N != 22 and M != 0 (ensured by the order of the patterns in the ArrayList)

--- a/src/test/java/com/databasepreservation/testing/integration/roundtrip/differences/PostgreSqlDumpDiffExpectations.java
+++ b/src/test/java/com/databasepreservation/testing/integration/roundtrip/differences/PostgreSqlDumpDiffExpectations.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 /**
  * PostgreSQL specific implementation to convert the source database dump to an expected version of the database dump
+ *
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class PostgreSqlDumpDiffExpectations extends DumpDiffExpectations {
@@ -17,9 +18,8 @@ public class PostgreSqlDumpDiffExpectations extends DumpDiffExpectations {
                 directReplacements = new ArrayList<Pair<Pattern, String>>();
 
                 // "char" -> character(1)
-                directReplacements.add(
-                  new ImmutablePair<Pattern, String>(Pattern.compile("(?<= )\"char\"(?= )"),
-                    "character(1)"));
+                directReplacements
+                  .add(new ImmutablePair<Pattern, String>(Pattern.compile("(?<= )\"char\"(?= )"), "character(1)"));
         }
 
         @Override protected String expectedTargetDatabaseDump(String source) {

--- a/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
+++ b/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
@@ -28,7 +28,7 @@ import com.databasepreservation.model.structure.type.SimpleTypeBinary;
 import com.databasepreservation.model.structure.type.SimpleTypeBoolean;
 import com.databasepreservation.model.structure.type.SimpleTypeNumericExact;
 import com.databasepreservation.model.structure.type.SimpleTypeString;
-import com.databasepreservation.modules.DatabaseHandler;
+import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.siard.in.input.SIARD1ImportModule;
 import com.databasepreservation.modules.siard.in.input.SIARD2ImportModule;
@@ -504,7 +504,7 @@ import java.util.Random;
          */
         private DatabaseStructure roundtrip(DatabaseStructure dbStructure, Path tmpFile, SIARDVersion version)
           throws FileNotFoundException, ModuleException, UnknownTypeException, InvalidDataException {
-                DatabaseHandler exporter = null;
+                DatabaseExportModule exporter = null;
 
                 switch (version) {
                         case SIARD_1:
@@ -547,7 +547,7 @@ import java.util.Random;
                 logger.debug("getting the data back from SIARD");
 
                 logger.debug("SIARD file: " + tmpFile.toUri().toString());
-                DatabaseHandler mocked = Mockito.mock(DatabaseHandler.class);
+                DatabaseExportModule mocked = Mockito.mock(DatabaseExportModule.class);
 
                 DatabaseImportModule importer = null;
                 switch (version) {

--- a/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestFactory.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestFactory.java
@@ -1,12 +1,18 @@
 package com.databasepreservation.testing.unit.cli;
 
 import com.databasepreservation.cli.CLI;
+import com.databasepreservation.cli.Parameter;
 import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.DatabaseModuleFactory;
 import org.apache.commons.cli.ParseException;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,37 +23,87 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ModuleFactoryTestFactory {
         private final Class<? extends DatabaseModuleFactory> module;
 
-        protected ModuleFactoryTestFactory(Class<? extends DatabaseModuleFactory> module){
+        protected ModuleFactoryTestFactory(Class<? extends DatabaseModuleFactory> module) {
                 this.module = module;
         }
 
-        protected CLI buildCli(String... args){
+        protected CLI buildCli(String... args) {
                 return new CLI(Arrays.asList(args), module);
         }
 
-        protected DatabaseImportModule getImportModule(Class<? extends DatabaseImportModule> importModuleClass,String... args){
-                DatabaseImportModule module;
-                try {
-                        module = buildCli(args).getImportModule();
-                } catch (ParseException e) {
-                        throw new RuntimeException(e);
-                }
-
-                assertThat("import module must be " + importModuleClass.toString(), module,
-                  instanceOf(importModuleClass));
-                return module;
+        protected HashMap<Parameter, String> getImportModuleArguments(String... args) {
+                return getModuleArguments(true, args);
         }
 
-        protected DatabaseExportModule getExportModule(Class<? extends DatabaseExportModule> exportModuleClass,String... args){
-                DatabaseExportModule module;
+        protected HashMap<Parameter, String> getExportModuleArguments(String... args) {
+                return getModuleArguments(false, args);
+        }
+
+        private HashMap<Parameter, String> getModuleArguments(boolean forImportModule, String... args) {
                 try {
-                        module = buildCli(args).getExportModule();
+                        CLI cli = new CLI(Arrays.asList(args), module);
+
+                        Method getModuleFactories = CLI.class.getDeclaredMethod("getModuleFactories", List.class);
+                        getModuleFactories.setAccessible(true);
+                        CLI.DatabaseModuleFactoriesPair databaseModuleFactoriesPair = (CLI.DatabaseModuleFactoriesPair) getModuleFactories
+                          .invoke(cli, Arrays.asList(args));
+
+                        Method getModuleArguments = CLI.class
+                          .getDeclaredMethod("getModuleArguments", CLI.DatabaseModuleFactoriesPair.class, List.class);
+                        getModuleArguments.setAccessible(true);
+                        CLI.DatabaseModuleFactoriesArguments databaseModuleFactoriesArguments = (CLI.DatabaseModuleFactoriesArguments) getModuleArguments
+                          .invoke(cli, databaseModuleFactoriesPair, Arrays.asList(args));
+
+                        if (forImportModule) {
+                                return databaseModuleFactoriesArguments.getImportModuleArguments();
+                        } else {
+                                return databaseModuleFactoriesArguments.getExportModuleArguments();
+                        }
+                } catch (NoSuchMethodException e) {
+                        throw new RuntimeException(e);
+                } catch (InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                }
+        }
+
+        protected Map<String, Parameter> getModuleParameters(String... args) {
+                try {
+                        CLI cli = new CLI(Arrays.asList(args), module);
+
+                        Method getModuleFactories = CLI.class.getDeclaredMethod("getModuleFactories", List.class);
+                        getModuleFactories.setAccessible(true);
+                        CLI.DatabaseModuleFactoriesPair databaseModuleFactoriesPair = (CLI.DatabaseModuleFactoriesPair) getModuleFactories
+                          .invoke(cli, Arrays.asList(args));
+
+                        return databaseModuleFactoriesPair.getImportModuleFactory().getAllParameters();
+                } catch (NoSuchMethodException e) {
+                        throw new RuntimeException(e);
+                } catch (InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                }
+        }
+
+        protected void assertCorrectModuleClass(Class<? extends DatabaseImportModule> importModuleClass,
+          Class<? extends DatabaseExportModule> exportModuleClass, String... args) {
+                CLI cli = buildCli(args);
+
+                DatabaseImportModule databaseImportModule;
+                DatabaseExportModule databaseExportModule;
+                try {
+                        databaseImportModule = cli.getImportModule();
+                        databaseExportModule = cli.getExportModule();
                 } catch (ParseException e) {
                         throw new RuntimeException(e);
                 }
 
-                assertThat("export module must be " + exportModuleClass.toString(), module,
+                assertThat("import module must be " + importModuleClass.toString(), databaseImportModule,
+                  instanceOf(importModuleClass));
+
+                assertThat("export module must be " + exportModuleClass.toString(), databaseExportModule,
                   instanceOf(exportModuleClass));
-                return module;
         }
 }

--- a/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestFactory.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestFactory.java
@@ -1,0 +1,53 @@
+package com.databasepreservation.testing.unit.cli;
+
+import com.databasepreservation.cli.CLI;
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.DatabaseModuleFactory;
+import org.apache.commons.cli.ParseException;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class ModuleFactoryTestFactory {
+        private final Class<? extends DatabaseModuleFactory> module;
+
+        protected ModuleFactoryTestFactory(Class<? extends DatabaseModuleFactory> module){
+                this.module = module;
+        }
+
+        protected CLI buildCli(String... args){
+                return new CLI(Arrays.asList(args), module);
+        }
+
+        protected DatabaseImportModule getImportModule(Class<? extends DatabaseImportModule> importModuleClass,String... args){
+                DatabaseImportModule module;
+                try {
+                        module = buildCli(args).getImportModule();
+                } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                }
+
+                assertThat("import module must be " + importModuleClass.toString(), module,
+                  instanceOf(importModuleClass));
+                return module;
+        }
+
+        protected DatabaseExportModule getExportModule(Class<? extends DatabaseExportModule> exportModuleClass,String... args){
+                DatabaseExportModule module;
+                try {
+                        module = buildCli(args).getExportModule();
+                } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                }
+
+                assertThat("export module must be " + exportModuleClass.toString(), module,
+                  instanceOf(exportModuleClass));
+                return module;
+        }
+}

--- a/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestHelper.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestHelper.java
@@ -9,6 +9,7 @@ import org.apache.commons.cli.ParseException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,14 +25,15 @@ import static org.hamcrest.Matchers.equalTo;
  */
 //TODO: incomplete because default values of optional parameters are not tested
 public class ModuleFactoryTestHelper {
-        private final Class<? extends DatabaseModuleFactory> module;
+        private final List<Class<? extends DatabaseModuleFactory>> module;
         private final Class<? extends DatabaseImportModule> importModuleClass;
         private final Class<? extends DatabaseExportModule> exportModuleClass;
 
         protected ModuleFactoryTestHelper(Class<? extends DatabaseModuleFactory> module,
           Class<? extends DatabaseImportModule> importModuleClass,
           Class<? extends DatabaseExportModule> exportModuleClass) {
-                this.module = module;
+                this.module = new ArrayList<Class<? extends DatabaseModuleFactory>>();
+                this.module.add(module);
                 this.importModuleClass = importModuleClass;
                 this.exportModuleClass = exportModuleClass;
         }

--- a/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestHelper.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestHelper.java
@@ -18,14 +18,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
+ * Helper class to help test ModuleFactories
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
-public class ModuleFactoryTestFactory {
+//TODO: incomplete because default values of optional parameters are not tested
+public class ModuleFactoryTestHelper {
         private final Class<? extends DatabaseModuleFactory> module;
         private final Class<? extends DatabaseImportModule> importModuleClass;
         private final Class<? extends DatabaseExportModule> exportModuleClass;
 
-        protected ModuleFactoryTestFactory(Class<? extends DatabaseModuleFactory> module,
+        protected ModuleFactoryTestHelper(Class<? extends DatabaseModuleFactory> module,
           Class<? extends DatabaseImportModule> importModuleClass,
           Class<? extends DatabaseExportModule> exportModuleClass) {
                 this.module = module;
@@ -112,7 +114,7 @@ public class ModuleFactoryTestFactory {
                   instanceOf(exportModuleClass));
         }
 
-        protected static void validate_arguments(ModuleFactoryTestFactory testFactory, List<String> args,
+        protected static void validate_arguments(ModuleFactoryTestHelper testFactory, List<String> args,
           HashMap<String, String> expectedImportValues, HashMap<String, String> expectedExportValues) {
                 // verify that arguments create the correct import and export modules
                 testFactory.assertCorrectModuleClass(args);

--- a/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestHelper.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/ModuleFactoryTestHelper.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Helper class to help test ModuleFactories
+ *
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 //TODO: incomplete because default values of optional parameters are not tested

--- a/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
@@ -78,7 +78,8 @@ import java.util.List;
                   .asList("--import=PostgreSQLJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
                     "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQLJDBC",
                     "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
-                    "--edatabase=another-db-name", "--idisable-encryption", "--iport-number=1234", "--eport-number=4321");
+                    "--edatabase=another-db-name", "--idisable-encryption", "--iport-number=1234",
+                    "--eport-number=4321");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();

--- a/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
@@ -26,7 +26,7 @@ import java.util.List;
                   .asList("--import=PostgreSQLJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
                     "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQLJDBC",
                     "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
-                    "--edatabase=another-db-name", "--ido-not-encrypt");
+                    "--edatabase=another-db-name", "--idisable-encryption");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
@@ -34,7 +34,7 @@ import java.util.List;
                 expectedValuesImport.put("database", "dbname");
                 expectedValuesImport.put("username", "name-user");
                 expectedValuesImport.put("password", "abc1 23=456");
-                expectedValuesImport.put("do-not-encrypt", "true");
+                expectedValuesImport.put("disable-encryption", "true");
 
                 // test parameters for export module
                 HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
@@ -51,7 +51,7 @@ import java.util.List;
                 List<String> args = Arrays
                   .asList("-i", "PostgreSQLJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
                     "-idb", "dbname", "-e", "PostgreSQLJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
-                    "another-server", "-edb", "another-db-name", "-ene");
+                    "another-server", "-edb", "another-db-name", "-ede");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
@@ -59,7 +59,7 @@ import java.util.List;
                 expectedValuesImport.put("database", "dbname");
                 expectedValuesImport.put("username", "name-user");
                 expectedValuesImport.put("password", "abc1 23=456");
-                //expectedValuesImport.put("do-not-encrypt", "");
+                //expectedValuesImport.put("disable-encryption", "");
 
                 // test parameters for export module
                 HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
@@ -67,7 +67,7 @@ import java.util.List;
                 expectedValuesExport.put("database", "another-db-name");
                 expectedValuesExport.put("username", "name-another-user");
                 expectedValuesExport.put("password", "2bcd123=456");
-                expectedValuesExport.put("do-not-encrypt", "true");
+                expectedValuesExport.put("disable-encryption", "true");
 
                 ModuleFactoryTestHelper
                   .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
@@ -78,7 +78,7 @@ import java.util.List;
                   .asList("--import=PostgreSQLJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
                     "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQLJDBC",
                     "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
-                    "--edatabase=another-db-name", "--ido-not-encrypt", "--iport-number=1234", "--eport-number=4321");
+                    "--edatabase=another-db-name", "--idisable-encryption", "--iport-number=1234", "--eport-number=4321");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
@@ -86,7 +86,7 @@ import java.util.List;
                 expectedValuesImport.put("database", "dbname");
                 expectedValuesImport.put("username", "name-user");
                 expectedValuesImport.put("password", "abc1 23=456");
-                expectedValuesImport.put("do-not-encrypt", "true");
+                expectedValuesImport.put("disable-encryption", "true");
                 expectedValuesImport.put("port-number", "1234");
 
                 // test parameters for export module
@@ -105,7 +105,7 @@ import java.util.List;
                 List<String> args = Arrays
                   .asList("-i", "PostgreSQLJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
                     "-idb", "dbname", "-e", "PostgreSQLJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
-                    "another-server", "-edb", "another-db-name", "-ene", "-ipn", "4567", "-epn", "7654");
+                    "another-server", "-edb", "another-db-name", "-ede", "-ipn", "4567", "-epn", "7654");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
@@ -121,7 +121,7 @@ import java.util.List;
                 expectedValuesExport.put("database", "another-db-name");
                 expectedValuesExport.put("username", "name-another-user");
                 expectedValuesExport.put("password", "2bcd123=456");
-                expectedValuesExport.put("do-not-encrypt", "true");
+                expectedValuesExport.put("disable-encryption", "true");
                 expectedValuesExport.put("port-number", "7654");
 
                 ModuleFactoryTestHelper

--- a/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
@@ -23,8 +23,8 @@ import java.util.List;
 
         @Test public void arguments_required_long() {
                 List<String> args = Arrays
-                  .asList("--import=PostgreSQL", "--iusername=name-user", "--ipassword=abc1 23=456",
-                    "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQL",
+                  .asList("--import=PostgreSQLJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQLJDBC",
                     "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
                     "--edatabase=another-db-name", "--ido-not-encrypt");
 
@@ -49,8 +49,8 @@ import java.util.List;
 
         @Test public void arguments_required_short() {
                 List<String> args = Arrays
-                  .asList("-i", "PostgreSQL", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
-                    "-idb", "dbname", "-e", "PostgreSQL", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
+                  .asList("-i", "PostgreSQLJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
+                    "-idb", "dbname", "-e", "PostgreSQLJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
                     "another-server", "-edb", "another-db-name", "-ene");
 
                 // test parameters for import module
@@ -75,8 +75,8 @@ import java.util.List;
 
         @Test public void arguments_portNumber_long() {
                 List<String> args = Arrays
-                  .asList("--import=PostgreSQL", "--iusername=name-user", "--ipassword=abc1 23=456",
-                    "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQL",
+                  .asList("--import=PostgreSQLJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQLJDBC",
                     "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
                     "--edatabase=another-db-name", "--ido-not-encrypt", "--iport-number=1234", "--eport-number=4321");
 
@@ -103,8 +103,8 @@ import java.util.List;
 
         @Test public void arguments_portNumber_short() {
                 List<String> args = Arrays
-                  .asList("-i", "PostgreSQL", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
-                    "-idb", "dbname", "-e", "PostgreSQL", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
+                  .asList("-i", "PostgreSQLJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
+                    "-idb", "dbname", "-e", "PostgreSQLJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
                     "another-server", "-edb", "another-db-name", "-ene", "-ipn", "4567", "-epn", "7654");
 
                 // test parameters for import module

--- a/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/PostgreSQLModuleFactoryTest.java
@@ -1,0 +1,130 @@
+package com.databasepreservation.testing.unit.cli;
+
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.postgreSql.PostgreSQLModuleFactory;
+import com.databasepreservation.modules.postgreSql.in.PostgreSQLJDBCImportModule;
+import com.databasepreservation.modules.postgreSql.out.PostgreSQLJDBCExportModule;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+@Test(groups = {"cli"}) public class PostgreSQLModuleFactoryTest {
+        private static Class<? extends DatabaseImportModule> importModuleClass = PostgreSQLJDBCImportModule.class;
+        private static Class<? extends DatabaseExportModule> exportModuleClass = PostgreSQLJDBCExportModule.class;
+
+        private static ModuleFactoryTestHelper testHelper = new ModuleFactoryTestHelper(PostgreSQLModuleFactory.class,
+          importModuleClass, exportModuleClass);
+
+        @Test public void arguments_required_long() {
+                List<String> args = Arrays
+                  .asList("--import=PostgreSQL", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQL",
+                    "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
+                    "--edatabase=another-db-name", "--ido-not-encrypt");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("hostname", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("do-not-encrypt", "true");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("hostname", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_required_short() {
+                List<String> args = Arrays
+                  .asList("-i", "PostgreSQL", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
+                    "-idb", "dbname", "-e", "PostgreSQL", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
+                    "another-server", "-edb", "another-db-name", "-ene");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("hostname", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                //expectedValuesImport.put("do-not-encrypt", "");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("hostname", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("do-not-encrypt", "true");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_portNumber_long() {
+                List<String> args = Arrays
+                  .asList("--import=PostgreSQL", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--ihostname=the-server-name", "--idatabase=dbname", "--export=PostgreSQL",
+                    "--eusername=name-another-user", "--epassword=2bcd123=456", "--ehostname=another-server",
+                    "--edatabase=another-db-name", "--ido-not-encrypt", "--iport-number=1234", "--eport-number=4321");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("hostname", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("do-not-encrypt", "true");
+                expectedValuesImport.put("port-number", "1234");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("hostname", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("port-number", "4321");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_portNumber_short() {
+                List<String> args = Arrays
+                  .asList("-i", "PostgreSQL", "-iu", "name-user", "-ip", "abc1 23=456", "-ih", "the-server-name",
+                    "-idb", "dbname", "-e", "PostgreSQL", "-eu", "name-another-user", "-ep", "2bcd123=456", "-eh",
+                    "another-server", "-edb", "another-db-name", "-ene", "-ipn", "4567", "-epn", "7654");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("hostname", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("port-number", "4567");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("hostname", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("do-not-encrypt", "true");
+                expectedValuesExport.put("port-number", "7654");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+}

--- a/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
@@ -25,9 +25,8 @@ import java.util.List;
                 List<String> args = Arrays
                   .asList("--import=SQLServerJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
                     "--iserver-name=the-server-name", "--idatabase=dbname", "--ido-not-encrypt",
-                    "--export=SQLServerJDBC",
-                    "--eusername=name-another-user", "--epassword=2bcd123=456", "--eserver-name=another-server",
-                    "--edatabase=another-db-name");
+                    "--export=SQLServerJDBC", "--eusername=name-another-user", "--epassword=2bcd123=456",
+                    "--eserver-name=another-server", "--edatabase=another-db-name");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();

--- a/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
@@ -1,6 +1,5 @@
 package com.databasepreservation.testing.unit.cli;
 
-import com.databasepreservation.cli.Parameter;
 import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory;
@@ -8,108 +7,66 @@ import com.databasepreservation.modules.sqlServer.in.SQLServerJDBCImportModule;
 import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import java.util.List;
 
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
 @Test(groups = {"cli"}) public class SQLServerJDBCModuleFactoryTest {
-        private static ModuleFactoryTestFactory testFactory = new ModuleFactoryTestFactory(
-          SQLServerJDBCModuleFactory.class);
-
         private static Class<? extends DatabaseImportModule> importModuleClass = SQLServerJDBCImportModule.class;
         private static Class<? extends DatabaseExportModule> exportModuleClass = SQLServerJDBCExportModule.class;
 
+        private static ModuleFactoryTestFactory testFactory = new ModuleFactoryTestFactory(
+          SQLServerJDBCModuleFactory.class, importModuleClass, exportModuleClass);
+
         @Test public void arguments_only_necessary_long() {
-                String[] args = new String[] {"--import=SQLServerJDBC", "--iusername=name-user",
-                  "--ipassword=abc1 23=456", "--iserver-name=the-server-name", "--idatabase=dbname",
-                  "--export=SQLServerJDBC", "--eusername=name-another-user", "--epassword=2bcd123=456",
-                  "--eserver-name=another-server", "--edatabase=another-db-name"};
-
-                // verify that arguments create the correct import and export modules
-                testFactory.assertCorrectModuleClass(importModuleClass, exportModuleClass, args);
-
-                // get information needed to test the actual parameters
-                Map<String, Parameter> parameters = testFactory.getModuleParameters(args);
-                HashMap<Parameter, String> importModuleArguments = testFactory.getImportModuleArguments(args);
-                HashMap<Parameter, String> exportModuleArguments = testFactory.getExportModuleArguments(args);
-
-                HashMap<String, String> expectedValues;
+                List<String> args = Arrays
+                  .asList("--import=SQLServerJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--iserver-name=the-server-name", "--idatabase=dbname", "--export=SQLServerJDBC",
+                    "--eusername=name-another-user", "--epassword=2bcd123=456", "--eserver-name=another-server",
+                    "--edatabase=another-db-name");
 
                 // test parameters for import module
-                expectedValues = new HashMap<String, String>();
-                expectedValues.put("username", "name-user");
-                expectedValues.put("password", "abc1 23=456");
-                expectedValues.put("server-name", "the-server-name");
-                expectedValues.put("database", "dbname");
-
-                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
-                        String property = entry.getKey();
-                        String expectation = entry.getValue();
-                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
-                          importModuleArguments.get(parameters.get(property)), equalTo(expectation));
-                }
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("server-name", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
 
                 // test parameters for export module
-                expectedValues = new HashMap<String, String>();
-                expectedValues.put("username", "name-another-user");
-                expectedValues.put("password", "2bcd123=456");
-                expectedValues.put("server-name", "another-server");
-                expectedValues.put("database", "another-db-name");
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("server-name", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
 
-                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
-                        String property = entry.getKey();
-                        String expectation = entry.getValue();
-                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
-                          exportModuleArguments.get(parameters.get(property)), equalTo(expectation));
-                }
+                ModuleFactoryTestFactory
+                  .validate_arguments(testFactory, args, expectedValuesImport, expectedValuesExport);
         }
 
         @Test public void arguments_only_necessary_short() {
-                String[] args = new String[] {"-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is",
-                  "the-server-name", "-idb", "dbname", "-e", "SQLServerJDBC", "-eu", "name-another-user", "-ep",
-                  "2bcd123=456", "-es", "another-server", "-edb", "another-db-name"};
-
-                // verify that arguments create the correct import and export modules
-                testFactory.assertCorrectModuleClass(importModuleClass, exportModuleClass, args);
-
-                // get information needed to test the actual parameters
-                Map<String, Parameter> parameters = testFactory.getModuleParameters(args);
-                HashMap<Parameter, String> importModuleArguments = testFactory.getImportModuleArguments(args);
-                HashMap<Parameter, String> exportModuleArguments = testFactory.getExportModuleArguments(args);
-
-                HashMap<String, String> expectedValues;
+                List<String> args = Arrays
+                  .asList("-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is", "the-server-name",
+                    "-idb", "dbname", "-e", "SQLServerJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-es",
+                    "another-server", "-edb", "another-db-name");
 
                 // test parameters for import module
-                expectedValues = new HashMap<String, String>();
-                expectedValues.put("username", "name-user");
-                expectedValues.put("password", "abc1 23=456");
-                expectedValues.put("server-name", "the-server-name");
-                expectedValues.put("database", "dbname");
-
-                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
-                        String property = entry.getKey();
-                        String expectation = entry.getValue();
-                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
-                          importModuleArguments.get(parameters.get(property)), equalTo(expectation));
-                }
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("server-name", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
 
                 // test parameters for export module
-                expectedValues = new HashMap<String, String>();
-                expectedValues.put("username", "name-another-user");
-                expectedValues.put("password", "2bcd123=456");
-                expectedValues.put("server-name", "another-server");
-                expectedValues.put("database", "another-db-name");
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("server-name", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
 
-                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
-                        String property = entry.getKey();
-                        String expectation = entry.getValue();
-                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
-                          exportModuleArguments.get(parameters.get(property)), equalTo(expectation));
-                }
+                ModuleFactoryTestFactory
+                  .validate_arguments(testFactory, args, expectedValuesImport, expectedValuesExport);
         }
 }

--- a/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
@@ -1,0 +1,34 @@
+package com.databasepreservation.testing.unit.cli;
+
+import com.databasepreservation.modules.DatabaseExportModule;
+import com.databasepreservation.modules.DatabaseImportModule;
+import com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory;
+import com.databasepreservation.modules.sqlServer.in.SQLServerJDBCImportModule;
+import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
+import org.testng.annotations.Test;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class SQLServerJDBCModuleFactoryTest {
+        private static ModuleFactoryTestFactory testFactory = new ModuleFactoryTestFactory(
+          SQLServerJDBCModuleFactory.class);
+
+        private static Class<? extends DatabaseImportModule> importModuleClass = SQLServerJDBCImportModule.class;
+        private static Class<? extends DatabaseExportModule> exportModuleClass = SQLServerJDBCExportModule.class;
+
+        @Test public void arguments1() {
+                String[] args = new String[] {"-i", "SQLServerJDBC", "--iusername=\"nome-de-utilizador\"",
+                  "--ipassword=\"ola123=456\"", "--iserver-name=\"nome-servidor\"", "--idatabase=\"dbname\"",
+                  "--export=SQLServerJDBC", "--eusername=\"2nome-de-utilizador\"", "--epassword=\"2ola123=456\"",
+                  "--eserver-name=\"2nome-servidor\"", "--edatabase=\"2dbname\""};
+
+                SQLServerJDBCImportModule importModule = (SQLServerJDBCImportModule) testFactory
+                  .getImportModule(importModuleClass, args);
+
+                SQLServerJDBCExportModule exportModule = (SQLServerJDBCExportModule) testFactory
+                  .getExportModule(exportModuleClass, args);
+
+
+        }
+}

--- a/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
@@ -1,5 +1,6 @@
 package com.databasepreservation.testing.unit.cli;
 
+import com.databasepreservation.cli.Parameter;
 import com.databasepreservation.modules.DatabaseExportModule;
 import com.databasepreservation.modules.DatabaseImportModule;
 import com.databasepreservation.modules.sqlServer.SQLServerJDBCModuleFactory;
@@ -7,28 +8,108 @@ import com.databasepreservation.modules.sqlServer.in.SQLServerJDBCImportModule;
 import com.databasepreservation.modules.sqlServer.out.SQLServerJDBCExportModule;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
-public class SQLServerJDBCModuleFactoryTest {
+@Test(groups = {"cli"}) public class SQLServerJDBCModuleFactoryTest {
         private static ModuleFactoryTestFactory testFactory = new ModuleFactoryTestFactory(
           SQLServerJDBCModuleFactory.class);
 
         private static Class<? extends DatabaseImportModule> importModuleClass = SQLServerJDBCImportModule.class;
         private static Class<? extends DatabaseExportModule> exportModuleClass = SQLServerJDBCExportModule.class;
 
-        @Test public void arguments1() {
-                String[] args = new String[] {"-i", "SQLServerJDBC", "--iusername=\"nome-de-utilizador\"",
-                  "--ipassword=\"ola123=456\"", "--iserver-name=\"nome-servidor\"", "--idatabase=\"dbname\"",
-                  "--export=SQLServerJDBC", "--eusername=\"2nome-de-utilizador\"", "--epassword=\"2ola123=456\"",
-                  "--eserver-name=\"2nome-servidor\"", "--edatabase=\"2dbname\""};
+        @Test public void arguments_only_necessary_long() {
+                String[] args = new String[] {"--import=SQLServerJDBC", "--iusername=name-user",
+                  "--ipassword=abc1 23=456", "--iserver-name=the-server-name", "--idatabase=dbname",
+                  "--export=SQLServerJDBC", "--eusername=name-another-user", "--epassword=2bcd123=456",
+                  "--eserver-name=another-server", "--edatabase=another-db-name"};
 
-                SQLServerJDBCImportModule importModule = (SQLServerJDBCImportModule) testFactory
-                  .getImportModule(importModuleClass, args);
+                // verify that arguments create the correct import and export modules
+                testFactory.assertCorrectModuleClass(importModuleClass, exportModuleClass, args);
 
-                SQLServerJDBCExportModule exportModule = (SQLServerJDBCExportModule) testFactory
-                  .getExportModule(exportModuleClass, args);
+                // get information needed to test the actual parameters
+                Map<String, Parameter> parameters = testFactory.getModuleParameters(args);
+                HashMap<Parameter, String> importModuleArguments = testFactory.getImportModuleArguments(args);
+                HashMap<Parameter, String> exportModuleArguments = testFactory.getExportModuleArguments(args);
 
+                HashMap<String, String> expectedValues;
 
+                // test parameters for import module
+                expectedValues = new HashMap<String, String>();
+                expectedValues.put("username", "name-user");
+                expectedValues.put("password", "abc1 23=456");
+                expectedValues.put("server-name", "the-server-name");
+                expectedValues.put("database", "dbname");
+
+                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
+                        String property = entry.getKey();
+                        String expectation = entry.getValue();
+                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
+                          importModuleArguments.get(parameters.get(property)), equalTo(expectation));
+                }
+
+                // test parameters for export module
+                expectedValues = new HashMap<String, String>();
+                expectedValues.put("username", "name-another-user");
+                expectedValues.put("password", "2bcd123=456");
+                expectedValues.put("server-name", "another-server");
+                expectedValues.put("database", "another-db-name");
+
+                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
+                        String property = entry.getKey();
+                        String expectation = entry.getValue();
+                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
+                          exportModuleArguments.get(parameters.get(property)), equalTo(expectation));
+                }
+        }
+
+        @Test public void arguments_only_necessary_short() {
+                String[] args = new String[] {"-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is",
+                  "the-server-name", "-idb", "dbname", "-e", "SQLServerJDBC", "-eu", "name-another-user", "-ep",
+                  "2bcd123=456", "-es", "another-server", "-edb", "another-db-name"};
+
+                // verify that arguments create the correct import and export modules
+                testFactory.assertCorrectModuleClass(importModuleClass, exportModuleClass, args);
+
+                // get information needed to test the actual parameters
+                Map<String, Parameter> parameters = testFactory.getModuleParameters(args);
+                HashMap<Parameter, String> importModuleArguments = testFactory.getImportModuleArguments(args);
+                HashMap<Parameter, String> exportModuleArguments = testFactory.getExportModuleArguments(args);
+
+                HashMap<String, String> expectedValues;
+
+                // test parameters for import module
+                expectedValues = new HashMap<String, String>();
+                expectedValues.put("username", "name-user");
+                expectedValues.put("password", "abc1 23=456");
+                expectedValues.put("server-name", "the-server-name");
+                expectedValues.put("database", "dbname");
+
+                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
+                        String property = entry.getKey();
+                        String expectation = entry.getValue();
+                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
+                          importModuleArguments.get(parameters.get(property)), equalTo(expectation));
+                }
+
+                // test parameters for export module
+                expectedValues = new HashMap<String, String>();
+                expectedValues.put("username", "name-another-user");
+                expectedValues.put("password", "2bcd123=456");
+                expectedValues.put("server-name", "another-server");
+                expectedValues.put("database", "another-db-name");
+
+                for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
+                        String property = entry.getKey();
+                        String expectation = entry.getValue();
+                        assertThat("Property '" + property + "' must have value '" + expectation + "'",
+                          exportModuleArguments.get(parameters.get(property)), equalTo(expectation));
+                }
         }
 }

--- a/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
@@ -24,7 +24,7 @@ import java.util.List;
         @Test public void arguments_required_long() {
                 List<String> args = Arrays
                   .asList("--import=SQLServerJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
-                    "--iserver-name=the-server-name", "--idatabase=dbname", "--ido-not-encrypt",
+                    "--iserver-name=the-server-name", "--idatabase=dbname", "--idisable-encryption",
                     "--export=SQLServerJDBC", "--eusername=name-another-user", "--epassword=2bcd123=456",
                     "--eserver-name=another-server", "--edatabase=another-db-name");
 
@@ -34,7 +34,7 @@ import java.util.List;
                 expectedValuesImport.put("password", "abc1 23=456");
                 expectedValuesImport.put("server-name", "the-server-name");
                 expectedValuesImport.put("database", "dbname");
-                expectedValuesImport.put("do-not-encrypt", "true");
+                expectedValuesImport.put("disable-encryption", "true");
 
                 // test parameters for export module
                 HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
@@ -51,7 +51,7 @@ import java.util.List;
                 List<String> args = Arrays
                   .asList("-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is", "the-server-name",
                     "-idb", "dbname", "-e", "SQLServerJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-es",
-                    "another-server", "-ene", "-edb", "another-db-name");
+                    "another-server", "-ede", "-edb", "another-db-name");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
@@ -66,7 +66,7 @@ import java.util.List;
                 expectedValuesExport.put("password", "2bcd123=456");
                 expectedValuesExport.put("server-name", "another-server");
                 expectedValuesExport.put("database", "another-db-name");
-                expectedValuesExport.put("do-not-encrypt", "true");
+                expectedValuesExport.put("disable-encryption", "true");
 
                 ModuleFactoryTestHelper
                   .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);

--- a/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
+++ b/src/test/java/com/databasepreservation/testing/unit/cli/SQLServerJDBCModuleFactoryTest.java
@@ -18,13 +18,14 @@ import java.util.List;
         private static Class<? extends DatabaseImportModule> importModuleClass = SQLServerJDBCImportModule.class;
         private static Class<? extends DatabaseExportModule> exportModuleClass = SQLServerJDBCExportModule.class;
 
-        private static ModuleFactoryTestFactory testFactory = new ModuleFactoryTestFactory(
+        private static ModuleFactoryTestHelper testHelper = new ModuleFactoryTestHelper(
           SQLServerJDBCModuleFactory.class, importModuleClass, exportModuleClass);
 
-        @Test public void arguments_only_necessary_long() {
+        @Test public void arguments_required_long() {
                 List<String> args = Arrays
                   .asList("--import=SQLServerJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
-                    "--iserver-name=the-server-name", "--idatabase=dbname", "--export=SQLServerJDBC",
+                    "--iserver-name=the-server-name", "--idatabase=dbname", "--ido-not-encrypt",
+                    "--export=SQLServerJDBC",
                     "--eusername=name-another-user", "--epassword=2bcd123=456", "--eserver-name=another-server",
                     "--edatabase=another-db-name");
 
@@ -34,6 +35,7 @@ import java.util.List;
                 expectedValuesImport.put("password", "abc1 23=456");
                 expectedValuesImport.put("server-name", "the-server-name");
                 expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("do-not-encrypt", "true");
 
                 // test parameters for export module
                 HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
@@ -42,15 +44,15 @@ import java.util.List;
                 expectedValuesExport.put("server-name", "another-server");
                 expectedValuesExport.put("database", "another-db-name");
 
-                ModuleFactoryTestFactory
-                  .validate_arguments(testFactory, args, expectedValuesImport, expectedValuesExport);
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
         }
 
-        @Test public void arguments_only_necessary_short() {
+        @Test public void arguments_required_short() {
                 List<String> args = Arrays
                   .asList("-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is", "the-server-name",
                     "-idb", "dbname", "-e", "SQLServerJDBC", "-eu", "name-another-user", "-ep", "2bcd123=456", "-es",
-                    "another-server", "-edb", "another-db-name");
+                    "another-server", "-ene", "-edb", "another-db-name");
 
                 // test parameters for import module
                 HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
@@ -65,8 +67,117 @@ import java.util.List;
                 expectedValuesExport.put("password", "2bcd123=456");
                 expectedValuesExport.put("server-name", "another-server");
                 expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("do-not-encrypt", "true");
 
-                ModuleFactoryTestFactory
-                  .validate_arguments(testFactory, args, expectedValuesImport, expectedValuesExport);
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_instanceName_short() {
+                List<String> args = Arrays
+                  .asList("-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is", "the-server-name",
+                    "-idb", "dbname", "-iin", "name-for-the-instance", "-e", "SQLServerJDBC", "-eu",
+                    "name-another-user", "-ep", "2bcd123=456", "-es", "another-server", "-edb", "another-db-name",
+                    "-ein", "name-for-another-instance");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("server-name", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("instance-name", "name-for-the-instance");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("server-name", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("instance-name", "name-for-another-instance");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_instanceName_long() {
+                List<String> args = Arrays
+                  .asList("--import=SQLServerJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--iserver-name=the-server-name", "--idatabase=dbname", "--iinstance-name=name-for-the-instance",
+                    "--export=SQLServerJDBC", "--eusername=name-another-user", "--epassword=2bcd123=456",
+                    "--eserver-name=another-server", "--edatabase=another-db-name",
+                    "--einstance-name=name-for-another-instance");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("server-name", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("instance-name", "name-for-the-instance");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("server-name", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("instance-name", "name-for-another-instance");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_portNumber_short() {
+                List<String> args = Arrays
+                  .asList("-i", "SQLServerJDBC", "-iu", "name-user", "-ip", "abc1 23=456", "-is", "the-server-name",
+                    "-idb", "dbname", "-ipn", "1234", "-e", "SQLServerJDBC", "-eu", "name-another-user", "-ep",
+                    "2bcd123=456", "-es", "another-server", "-edb", "another-db-name", "-epn", "4321");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("server-name", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("port-number", "1234");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("server-name", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("port-number", "4321");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
+        }
+
+        @Test public void arguments_portNumber_long() {
+                List<String> args = Arrays
+                  .asList("--import=SQLServerJDBC", "--iusername=name-user", "--ipassword=abc1 23=456",
+                    "--iserver-name=the-server-name", "--idatabase=dbname", "--iport-number=1234",
+                    "--export=SQLServerJDBC", "--eusername=name-another-user", "--epassword=2bcd123=456",
+                    "--eserver-name=another-server", "--edatabase=another-db-name", "--eport-number=4321");
+
+                // test parameters for import module
+                HashMap<String, String> expectedValuesImport = new HashMap<String, String>();
+                expectedValuesImport.put("username", "name-user");
+                expectedValuesImport.put("password", "abc1 23=456");
+                expectedValuesImport.put("server-name", "the-server-name");
+                expectedValuesImport.put("database", "dbname");
+                expectedValuesImport.put("port-number", "1234");
+
+                // test parameters for export module
+                HashMap<String, String> expectedValuesExport = new HashMap<String, String>();
+                expectedValuesExport.put("username", "name-another-user");
+                expectedValuesExport.put("password", "2bcd123=456");
+                expectedValuesExport.put("server-name", "another-server");
+                expectedValuesExport.put("database", "another-db-name");
+                expectedValuesExport.put("port-number", "4321");
+
+                ModuleFactoryTestHelper
+                  .validate_arguments(testHelper, args, expectedValuesImport, expectedValuesExport);
         }
 }

--- a/testng.xml
+++ b/testng.xml
@@ -8,6 +8,7 @@
                 <include name="postgresql-siard1"/>
                 <include name="mysql-siard1"/>
                 <include name="siard-roundtrip"/>
+                <include name="cli"/>
             </define>
 
             <!-- Tests ran by Travis CI -->
@@ -15,11 +16,13 @@
                 <include name="postgresql-siard1"/>
                 <include name="mysql-siard1"/>
                 <include name="siard-roundtrip"/>
+                <include name="cli"/>
             </define>
 
             <!-- Tests that don't have external dependencies -->
             <define name="no-dependencies">
                 <include name="siard-roundtrip"/>
+                <include name="cli"/>
             </define>
 
             <!-- Default group of tests to run -->
@@ -31,6 +34,7 @@
             <class name="com.databasepreservation.testing.integration.roundtrip.MySqlTest"/>
             <class name="com.databasepreservation.testing.integration.roundtrip.PostgreSqlTest"/>
             <class name="com.databasepreservation.testing.integration.siard.SiardTest"/>
+            <class name="com.databasepreservation.testing.unit.cli.SQLServerJDBCModuleFactoryTest"/>
         </classes>
     </test>
 </suite>

--- a/vendor-libs/repository/ch/admin/bar/siard1-jaxb/1.0.1/siard1-jaxb-1.0.1.pom
+++ b/vendor-libs/repository/ch/admin/bar/siard1-jaxb/1.0.1/siard1-jaxb-1.0.1.pom
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>ch.admin.bar</groupId>
-  <artifactId>siard1-jaxb</artifactId>
-  <version>1.0.1</version>
-  <description>POM was created from install:install-file</description>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ch.admin.bar</groupId>
+    <artifactId>siard1-jaxb</artifactId>
+    <version>1.0.1</version>
+    <description>POM was created from install:install-file</description>
 </project>

--- a/vendor-libs/repository/ch/admin/bar/siard1-jaxb/maven-metadata-local.xml
+++ b/vendor-libs/repository/ch/admin/bar/siard1-jaxb/maven-metadata-local.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <groupId>ch.admin.bar</groupId>
-  <artifactId>siard1-jaxb</artifactId>
-  <versioning>
-    <release>1.0.1</release>
-    <versions>
-      <version>1.0.1</version>
-    </versions>
-    <lastUpdated>20150825105451</lastUpdated>
-  </versioning>
+    <groupId>ch.admin.bar</groupId>
+    <artifactId>siard1-jaxb</artifactId>
+    <versioning>
+        <release>1.0.1</release>
+        <versions>
+            <version>1.0.1</version>
+        </versions>
+        <lastUpdated>20150825105451</lastUpdated>
+    </versioning>
 </metadata>

--- a/vendor-libs/repository/ch/admin/bar/siard2-jaxb/1.0.1/siard2-jaxb-1.0.1.pom
+++ b/vendor-libs/repository/ch/admin/bar/siard2-jaxb/1.0.1/siard2-jaxb-1.0.1.pom
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>ch.admin.bar</groupId>
-  <artifactId>siard2-jaxb</artifactId>
-  <version>1.0.1</version>
-  <description>POM was created from install:install-file</description>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ch.admin.bar</groupId>
+    <artifactId>siard2-jaxb</artifactId>
+    <version>1.0.1</version>
+    <description>POM was created from install:install-file</description>
 </project>

--- a/vendor-libs/repository/ch/admin/bar/siard2-jaxb/maven-metadata-local.xml
+++ b/vendor-libs/repository/ch/admin/bar/siard2-jaxb/maven-metadata-local.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <groupId>ch.admin.bar</groupId>
-  <artifactId>siard2-jaxb</artifactId>
-  <versioning>
-    <release>1.0.1</release>
-    <versions>
-      <version>1.0.1</version>
-    </versions>
-    <lastUpdated>20150825105456</lastUpdated>
-  </versioning>
+    <groupId>ch.admin.bar</groupId>
+    <artifactId>siard2-jaxb</artifactId>
+    <versioning>
+        <release>1.0.1</release>
+        <versions>
+            <version>1.0.1</version>
+        </versions>
+        <lastUpdated>20150825105456</lastUpdated>
+    </versioning>
 </metadata>


### PR DESCRIPTION
The CLI uses special factory classes that not only create modules but also provide information about the parameters supported by the module to parse the command line arguments. To be usable by CLI, each module should have a factory implementing the DatabaseModuleFactory interface and a new instance of that factory should be added to CLI initialization in internal_main.