### PR TITLE
Pretty XML output is now bound to its corresponding command line argument

### DIFF
--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD1ModuleFactory.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD1ModuleFactory.java
@@ -89,7 +89,6 @@ public class SIARD1ModuleFactory implements DatabaseModuleFactory {
       pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfSet());
     }
 
-    // TODO: prettyXML
-    return new SIARD1ExportModule(Paths.get(pFile), pCompress).getDatabaseHandler();
+    return new SIARD1ExportModule(Paths.get(pFile), pCompress, pPrettyPrintXML).getDatabaseHandler();
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD2ModuleFactory.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD2ModuleFactory.java
@@ -100,7 +100,6 @@ public class SIARD2ModuleFactory implements DatabaseModuleFactory {
       pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfSet());
     }
 
-    // TODO: prettyXML
-    return new SIARD2ExportModule(Paths.get(pFile), pCompress).getDatabaseHandler();
+    return new SIARD2ExportModule(Paths.get(pFile), pCompress, pPrettyPrintXML).getDatabaseHandler();
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
@@ -28,7 +28,7 @@ public class SIARD1ExportModule {
   private MetadataExportStrategy metadataStrategy;
   private ContentExportStrategy contentStrategy;
 
-  public SIARD1ExportModule(Path siardPackage, boolean compressZip) {
+  public SIARD1ExportModule(Path siardPackage, boolean compressZip, boolean prettyXML) {
     contentPathStrategy = new SIARD1ContentPathExportStrategy();
     metadataPathStrategy = new SIARD1MetadataPathStrategy();
     if (compressZip) {
@@ -39,8 +39,7 @@ public class SIARD1ExportModule {
     mainContainer = new SIARDArchiveContainer(siardPackage, SIARDArchiveContainer.OutputContainerType.MAIN);
 
     metadataStrategy = new SIARD1MetadataExportStrategy(metadataPathStrategy, contentPathStrategy);
-    // TODO: change prettyXML from 'true' to a module argument
-    contentStrategy = new SIARD1ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer, true);
+    contentStrategy = new SIARD1ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer, prettyXML);
   }
 
   public DatabaseExportModule getDatabaseHandler() {

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
@@ -28,7 +28,7 @@ public class SIARD2ExportModule {
   private MetadataExportStrategy metadataStrategy;
   private ContentExportStrategy contentStrategy;
 
-  public SIARD2ExportModule(Path siardPackage, boolean compressZip) {
+  public SIARD2ExportModule(Path siardPackage, boolean compressZip, boolean prettyXML) {
     contentPathStrategy = new SIARD2ContentPathExportStrategy();
     metadataPathStrategy = new SIARD2MetadataPathStrategy();
     if (compressZip) {
@@ -39,8 +39,7 @@ public class SIARD2ExportModule {
     mainContainer = new SIARDArchiveContainer(siardPackage, SIARDArchiveContainer.OutputContainerType.MAIN);
 
     metadataStrategy = new SIARD2MetadataExportStrategy(metadataPathStrategy, contentPathStrategy);
-    // TODO: change prettyXML from 'true' to a module argument
-    contentStrategy = new SIARD2ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer, true);
+    contentStrategy = new SIARD2ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer, prettyXML);
   }
 
   public DatabaseExportModule getDatabaseHandler() {

--- a/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
@@ -507,10 +507,10 @@ public class SiardTest {
 
     switch (version) {
       case SIARD_1:
-        exporter = new SIARD1ExportModule(tmpFile, true).getDatabaseHandler();
+        exporter = new SIARD1ExportModule(tmpFile, true, false).getDatabaseHandler();
         break;
       case SIARD_2:
-        exporter = new SIARD2ExportModule(tmpFile, true).getDatabaseHandler();
+        exporter = new SIARD2ExportModule(tmpFile, true, false).getDatabaseHandler();
         break;
     }
 


### PR DESCRIPTION
ie: if --export-pretty-xml or -ep is passed when exporting SIARD1 or SIARD2, the content XML and XSD files are formatted so they are easier to read by humans.