### PR TITLE
Adds SQL2003 standard support

### DIFF
--- a/dbptk-core/src/main/java/com/databasepreservation/modules/db2/in/DB2JDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/db2/in/DB2JDBCImportModule.java
@@ -87,9 +87,11 @@ public class DB2JDBCImportModule extends JDBCImportModule {
     if (typeName.equalsIgnoreCase("XML")) {
       type = new SimpleTypeString(31457280, true);
       type.setSql99TypeName("CHARACTER LARGE OBJECT");
+      type.setSql2003TypeName("CHARACTER LARGE OBJECT");
     } else if (typeName.equalsIgnoreCase("DECFLOAT")) {
       type = new SimpleTypeNumericApproximate(Integer.valueOf(columnSize));
-      type.setSql99TypeName("DOUBLE");
+      type.setSql99TypeName("DOUBLE PRECISION");
+      type.setSql2003TypeName("DOUBLE PRECISION");
     } else {
       type = super.getOtherType(dataType, typeName, columnSize, decimalDigits, numPrecRadix);
     }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -757,8 +757,10 @@ public class JDBCImportModule implements DatabaseImportModule {
         type = new SimpleTypeNumericExact(columnSize, decimalDigits);
         if (decimalDigits > 0) {
           type.setSql99TypeName("NUMERIC", columnSize, decimalDigits);
+          type.setSql2003TypeName("NUMERIC", columnSize, decimalDigits);
         } else {
           type.setSql99TypeName("NUMERIC", columnSize);
+          type.setSql2003TypeName("NUMERIC", columnSize);
         }
         break;
       case Types.BINARY:
@@ -770,15 +772,18 @@ public class JDBCImportModule implements DatabaseImportModule {
         } else {
           type = new SimpleTypeBoolean();
           type.setSql99TypeName("BOOLEAN");
+          type.setSql2003TypeName("BOOLEAN");
         }
         break;
       case Types.BLOB:
         type = new SimpleTypeBinary(columnSize);
         type.setSql99TypeName("BINARY LARGE OBJECT");
+        type.setSql2003TypeName("BINARY LARGE OBJECT");
         break;
       case Types.BOOLEAN:
         type = new SimpleTypeBoolean();
         type.setSql99TypeName("BOOLEAN");
+        type.setSql2003TypeName("BOOLEAN");
         break;
       case Types.CHAR:
         type = new SimpleTypeString(columnSize, false);
@@ -789,10 +794,12 @@ public class JDBCImportModule implements DatabaseImportModule {
         // TODO add charset
         type = new SimpleTypeString(columnSize, false);
         type.setSql99TypeName("CHARACTER", columnSize);
+        type.setSql2003TypeName("CHARACTER", columnSize);
         break;
       case Types.CLOB:
         type = new SimpleTypeString(columnSize, true);
         type.setSql99TypeName("CHARACTER LARGE OBJECT");
+        type.setSql2003TypeName("CHARACTER LARGE OBJECT");
         break;
       case Types.DATE:
         type = getDateType(typeName, columnSize, decimalDigits, numPrecRadix);
@@ -810,6 +817,7 @@ public class JDBCImportModule implements DatabaseImportModule {
       case Types.INTEGER:
         type = new SimpleTypeNumericExact(columnSize, decimalDigits);
         type.setSql99TypeName("INTEGER");
+        type.setSql2003TypeName("INTEGER");
         break;
       case Types.LONGVARBINARY:
         type = getLongvarbinaryType(typeName, columnSize, decimalDigits, numPrecRadix);
@@ -820,6 +828,7 @@ public class JDBCImportModule implements DatabaseImportModule {
       case Types.LONGNVARCHAR:
         type = new SimpleTypeString(columnSize, true);
         type.setSql99TypeName("CHARACTER LARGE OBJECT");
+        type.setSql2003TypeName("CHARACTER LARGE OBJECT");
         break;
       case Types.NUMERIC:
         type = getNumericType(typeName, columnSize, decimalDigits, numPrecRadix);
@@ -830,6 +839,7 @@ public class JDBCImportModule implements DatabaseImportModule {
       case Types.SMALLINT:
         type = new SimpleTypeNumericExact(columnSize, decimalDigits);
         type.setSql99TypeName("SMALLINT");
+        type.setSql2003TypeName("SMALLINT");
         break;
       case Types.TIME:
         type = getTimeType(typeName, columnSize, decimalDigits, numPrecRadix);
@@ -840,6 +850,7 @@ public class JDBCImportModule implements DatabaseImportModule {
       case Types.TINYINT:
         type = new SimpleTypeNumericExact(columnSize, decimalDigits);
         type.setSql99TypeName("SMALLINT");
+        type.setSql2003TypeName("SMALLINT");
         break;
       case Types.VARBINARY:
         type = getVarbinaryType(typeName, columnSize, decimalDigits, numPrecRadix);
@@ -851,6 +862,7 @@ public class JDBCImportModule implements DatabaseImportModule {
         // TODO add charset
         type = new SimpleTypeString(columnSize, true);
         type.setSql99TypeName("CHARACTER VARYING", columnSize);
+        type.setSql2003TypeName("CHARACTER VARYING", columnSize);
         break;
       case Types.ARRAY:
         Type subtype = getArraySubTypeFromTypeName(typeName, columnSize, numPrecRadix, numPrecRadix);
@@ -883,13 +895,16 @@ public class JDBCImportModule implements DatabaseImportModule {
 
   protected Type getVarbinaryType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeBinary(columnSize);
-    type.setSql99TypeName("BIT VARYING");
+    type.setSql99TypeName("BIT VARYING",columnSize);
+    type.setSql2003TypeName("BINARY LARGE OBJECT");
+    logger.info("using BIT VARYING(" + columnSize + ")");
     return type;
   }
 
   protected Type getRealType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeNumericApproximate(columnSize);
     type.setSql99TypeName("REAL");
+    type.setSql2003TypeName("REAL");
     return type;
   }
 
@@ -899,6 +914,7 @@ public class JDBCImportModule implements DatabaseImportModule {
     if (typeName.equals("_char")) {
       subtype = new SimpleTypeString(columnSize, false);
       subtype.setSql99TypeName("CHARACTER");
+      subtype.setSql2003TypeName("CHARACTER");
 
     } else if (typeName.equals("_abstime")) {
       subtype = getTimeType(typeName, columnSize, decimalDigits, numPrecRadix);
@@ -915,6 +931,7 @@ public class JDBCImportModule implements DatabaseImportModule {
   protected Type getBinaryType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeBinary(columnSize);
     type.setSql99TypeName("BIT");
+    type.setSql2003TypeName("BIT");
     type.setOriginalTypeName(typeName, columnSize);
     return type;
   }
@@ -922,6 +939,7 @@ public class JDBCImportModule implements DatabaseImportModule {
   protected Type getDateType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeDateTime(false, false);
     type.setSql99TypeName("DATE");
+    type.setSql2003TypeName("DATE");
     return type;
   }
 
@@ -929,8 +947,10 @@ public class JDBCImportModule implements DatabaseImportModule {
     Type type = new SimpleTypeNumericExact(columnSize, decimalDigits);
     if (decimalDigits > 0) {
       type.setSql99TypeName("DECIMAL", columnSize, decimalDigits);
+      type.setSql2003TypeName("DECIMAL", columnSize, decimalDigits);
     } else {
       type.setSql99TypeName("DECIMAL", columnSize);
+      type.setSql2003TypeName("DECIMAL", columnSize);
     }
     return type;
   }
@@ -939,8 +959,10 @@ public class JDBCImportModule implements DatabaseImportModule {
     Type type = new SimpleTypeNumericExact(columnSize, decimalDigits);
     if (decimalDigits > 0) {
       type.setSql99TypeName("NUMERIC", columnSize, decimalDigits);
+      type.setSql2003TypeName("NUMERIC", columnSize, decimalDigits);
     } else {
       type.setSql99TypeName("NUMERIC", columnSize);
+      type.setSql2003TypeName("NUMERIC", columnSize);
     }
     return type;
   }
@@ -948,18 +970,21 @@ public class JDBCImportModule implements DatabaseImportModule {
   protected Type getDoubleType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeNumericApproximate(columnSize);
     type.setSql99TypeName("DOUBLE PRECISION");
+    type.setSql2003TypeName("DOUBLE PRECISION");
     return type;
   }
 
   protected Type getFloatType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeNumericApproximate(columnSize);
     type.setSql99TypeName("FLOAT");
+    type.setSql2003TypeName("FLOAT");
     return type;
   }
 
   protected Type getLongvarbinaryType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeBinary(columnSize);
     type.setSql99TypeName("BINARY LARGE OBJECT");
+    type.setSql2003TypeName("BINARY LARGE OBJECT");
     return type;
   }
 
@@ -967,24 +992,28 @@ public class JDBCImportModule implements DatabaseImportModule {
     throws UnknownTypeException {
     Type type = new SimpleTypeString(columnSize, true);
     type.setSql99TypeName("CHARACTER LARGE OBJECT");
+    type.setSql2003TypeName("CHARACTER LARGE OBJECT");
     return type;
   }
 
   protected Type getTimeType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeDateTime(true, false);
     type.setSql99TypeName("TIME");
+    type.setSql2003TypeName("TIME");
     return type;
   }
 
   protected Type getTimestampType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeDateTime(true, false);
     type.setSql99TypeName("TIMESTAMP");
+    type.setSql2003TypeName("TIMESTAMP");
     return type;
   }
 
   protected Type getVarcharType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeString(columnSize, true);
     type.setSql99TypeName("CHARACTER VARYING", columnSize);
+    type.setSql2003TypeName("CHARACTER VARYING", columnSize);
     return type;
   }
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/mySql/in/MySQLJDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/mySql/in/MySQLJDBCImportModule.java
@@ -25,7 +25,8 @@ import com.databasepreservation.modules.jdbc.in.JDBCImportModule;
 import com.databasepreservation.modules.mySql.MySQLHelper;
 
 /**
- * @author Luis Faria
+ * @author Luis Faria <lfaria@keep.pt>
+ * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public class MySQLJDBCImportModule extends JDBCImportModule {
 
@@ -123,6 +124,7 @@ public class MySQLJDBCImportModule extends JDBCImportModule {
     if (columnSize == 12 && decimalDigits == 0) {
       type = new SimpleTypeNumericApproximate(columnSize);
       type.setSql99TypeName("REAL");
+      type.setSql2003TypeName("REAL");
     } else {
       type = getDecimalType(typeName, columnSize, decimalDigits, numPrecRadix);
     }
@@ -137,6 +139,7 @@ public class MySQLJDBCImportModule extends JDBCImportModule {
     if (columnSize == 22 && decimalDigits == 0) {
       type = new SimpleTypeNumericApproximate(columnSize);
       type.setSql99TypeName("DOUBLE PRECISION");
+      type.setSql2003TypeName("DOUBLE PRECISION");
     } else {
       type = getDecimalType(typeName, columnSize, decimalDigits, numPrecRadix);
     }
@@ -149,12 +152,15 @@ public class MySQLJDBCImportModule extends JDBCImportModule {
     Type type = new SimpleTypeBinary(columnSize);
 
     if (typeName.equalsIgnoreCase("TINYBLOB")) {
-      type.setSql99TypeName("BIT VARYING(2040)");
+      type.setSql99TypeName("BIT VARYING", 2040);
+      type.setSql2003TypeName("BINARY LARGE OBJECT");
     } else if (typeName.equalsIgnoreCase("BIT")) {
       type.setSql99TypeName("BIT", columnSize);
+      type.setSql2003TypeName("BIT", columnSize);
       type.setOriginalTypeName(typeName, columnSize);
     } else {
       type.setSql99TypeName("BIT", columnSize * 8);
+      type.setSql2003TypeName("BIT", columnSize * 8);
     }
 
     return type;
@@ -164,6 +170,7 @@ public class MySQLJDBCImportModule extends JDBCImportModule {
   protected Type getVarbinaryType(String typeName, int columnSize, int decimalDigits, int numPrecRadix) {
     Type type = new SimpleTypeBinary(columnSize);
     type.setSql99TypeName("BIT VARYING", columnSize * 8);
+    type.setSql2003TypeName("BIT VARYING", columnSize * 8);
     return type;
   }
 
@@ -191,6 +198,7 @@ public class MySQLJDBCImportModule extends JDBCImportModule {
     if (columnSize == 12 && decimalDigits == 0) {
       type = new SimpleTypeNumericApproximate(columnSize);
       type.setSql99TypeName("FLOAT");
+      type.setSql2003TypeName("FLOAT");
     } else {
       type = getDecimalType(typeName, columnSize, decimalDigits, numPrecRadix);
     }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/oracle/in/Oracle12cJDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/oracle/in/Oracle12cJDBCImportModule.java
@@ -85,18 +85,23 @@ public class Oracle12cJDBCImportModule extends JDBCImportModule {
     if (typeName.equalsIgnoreCase("NCHAR")) {
       type = new SimpleTypeString(Integer.valueOf(columnSize), false, "CHARSET");
       type.setSql99TypeName("CHARACTER");
+      type.setSql2003TypeName("CHARACTER");
     } else if (typeName.equalsIgnoreCase("NVARCHAR2")) {
       type = new SimpleTypeString(Integer.valueOf(columnSize), true, "CHARSET");
-      type.setSql99TypeName("CHARACTER VARYING");
+      type.setSql99TypeName("CHARACTER VARYING", columnSize);
+      type.setSql2003TypeName("CHARACTER VARYING", columnSize);
     } else if (typeName.equalsIgnoreCase("NCLOB")) {
       type = new SimpleTypeString(Integer.valueOf(columnSize), true, "CHARSET");
       type.setSql99TypeName("CHARACTER LARGE OBJECT");
+      type.setSql2003TypeName("CHARACTER LARGE OBJECT");
     } else if (typeName.equalsIgnoreCase("ROWID")) {
       type = new SimpleTypeString(Integer.valueOf(columnSize), true);
-      type.setSql99TypeName("CHARACTER VARYING");
+      type.setSql99TypeName("CHARACTER VARYING", columnSize);
+      type.setSql2003TypeName("CHARACTER VARYING", columnSize);
     } else if (typeName.equalsIgnoreCase("UROWID")) {
       type = new SimpleTypeString(Integer.valueOf(columnSize), true);
-      type.setSql99TypeName("CHARACTER VARYING");
+      type.setSql99TypeName("CHARACTER VARYING", columnSize);
+      type.setSql2003TypeName("CHARACTER VARYING", columnSize);
     } else {
       type = super.getOtherType(dataType, typeName, columnSize, decimalDigits, numPrecRadix);
     }
@@ -110,11 +115,13 @@ public class Oracle12cJDBCImportModule extends JDBCImportModule {
     switch (dataType) {
       case OracleTypes.BINARY_DOUBLE:
         type = new SimpleTypeNumericApproximate(Integer.valueOf(columnSize));
-        type.setSql99TypeName("BIT VARYING");
+        type.setSql99TypeName("BIT VARYING", columnSize); //todo: not sure if columnSize is the correct value here
+        type.setSql2003TypeName("BIT VARYING", columnSize); //todo: not sure if columnSize is the correct value here
         break;
       case OracleTypes.BINARY_FLOAT:
         type = new SimpleTypeNumericApproximate(Integer.valueOf(columnSize));
-        type.setSql99TypeName("BIT VARYING");
+        type.setSql99TypeName("BIT VARYING", columnSize); //todo: not sure if columnSize is the correct value here
+        type.setSql2003TypeName("BIT VARYING", columnSize); //todo: not sure if columnSize is the correct value here
         break;
       // TODO add support to BFILEs
       // case OracleTypes.BFILE:
@@ -123,10 +130,12 @@ public class Oracle12cJDBCImportModule extends JDBCImportModule {
       case OracleTypes.TIMESTAMPTZ:
         type = new SimpleTypeDateTime(true, true);
         type.setSql99TypeName("TIMESTAMP");
+        type.setSql2003TypeName("TIMESTAMP");
         break;
       case OracleTypes.TIMESTAMPLTZ:
         type = new SimpleTypeDateTime(true, true);
         type.setSql99TypeName("TIMESTAMP");
+        type.setSql2003TypeName("TIMESTAMP");
         break;
       default:
         type = super.getSpecificType(dataType, typeName, columnSize, decimalDigits, numPrecRadix);

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
@@ -155,8 +155,10 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
     Type type = new SimpleTypeBinary(columnSize);
     if (typeName.equalsIgnoreCase("bytea")) {
       type.setSql99TypeName("BINARY LARGE OBJECT");
+      type.setSql2003TypeName("BINARY LARGE OBJECT");
     } else {
       type.setSql99TypeName("BIT");
+      type.setSql2003TypeName("BIT");
     }
     return type;
   }
@@ -169,6 +171,7 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
     }
     Type type = new SimpleTypeNumericApproximate(columnSize);
     type.setSql99TypeName("DOUBLE PRECISION");
+    type.setSql2003TypeName("DOUBLE PRECISION");
     return type;
   }
 
@@ -178,9 +181,11 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
     if (typeName.equalsIgnoreCase("TIMETZ")) {
       type = new SimpleTypeDateTime(true, true);
       type.setSql99TypeName("TIME WITH TIME ZONE");
+      type.setSql2003TypeName("TIME WITH TIME ZONE");
     } else {
       type = new SimpleTypeDateTime(true, false);
       type.setSql99TypeName("TIME");
+      type.setSql2003TypeName("TIME");
     }
 
     return type;
@@ -192,9 +197,11 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
     if (typeName.equalsIgnoreCase("TIMESTAMPTZ")) {
       type = new SimpleTypeDateTime(true, true);
       type.setSql99TypeName("TIMESTAMP WITH TIME ZONE");
+      type.setSql2003TypeName("TIMESTAMP WITH TIME ZONE");
     } else {
       type = new SimpleTypeDateTime(true, false);
       type.setSql99TypeName("TIMESTAMP");
+      type.setSql2003TypeName("TIMESTAMP");
     }
 
     return type;
@@ -205,8 +212,10 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
     Type type = new SimpleTypeString(columnSize, true);
     if (typeName.equalsIgnoreCase("text")) {
       type.setSql99TypeName("CHARACTER LARGE OBJECT");
+      type.setSql2003TypeName("CHARACTER LARGE OBJECT");
     } else {
-      type.setSql99TypeName("CHARACTER VARYING");
+      type.setSql99TypeName("CHARACTER VARYING",columnSize);
+      type.setSql2003TypeName("CHARACTER VARYING",columnSize);
     }
     return type;
   }
@@ -221,6 +230,7 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
       case 2009: // XML Data type
         type = new SimpleTypeString(columnSize, true);
         type.setSql99TypeName("CHARACTER LARGE OBJECT");
+        type.setSql2003TypeName("CHARACTER LARGE OBJECT");
         break;
       default:
         type = super.getSpecificType(dataType, typeName, columnSize, decimalDigits, numPrecRadix);

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD2MetadataImportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/metadata/SIARD2MetadataImportStrategy.java
@@ -336,7 +336,7 @@ public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
 
       result.setName(parameterType.getName());
       result.setMode(parameterType.getMode());
-      result.setType(TypeConverterFactory.getSQL99TypeConverter().getType(parameterType.getType(),
+      result.setType(TypeConverterFactory.getSQL2003TypeConverter().getType(parameterType.getType(),
         parameterType.getTypeOriginal()));
       result.setDescription(parameterType.getDescription());
 
@@ -588,7 +588,8 @@ public class SIARD2MetadataImportStrategy implements MetadataImportStrategy {
       result.setId(tableId + "." + result.getName());
       contentPathStrategy.associateColumnWithFolder(result.getId(), column.getFolder());
 
-      result.setType(TypeConverterFactory.getSQL99TypeConverter().getType(column.getType(), column.getTypeOriginal()));
+      result
+        .setType(TypeConverterFactory.getSQL2003TypeConverter().getType(column.getType(), column.getTypeOriginal()));
 
       result.setNillable(column.isNullable());
       result.setDefaultValue(column.getDefaultValue());

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/metadata/typeConverter/SQL2003TypeConverter.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/metadata/typeConverter/SQL2003TypeConverter.java
@@ -10,12 +10,12 @@ import com.databasepreservation.model.structure.type.SimpleTypeString;
 import com.databasepreservation.model.structure.type.Type;
 
 /**
- * Converts a SQL99 normalized type to an internal type structure.
+ * Converts a SQL2003 normalized type to an internal type structure.
  *
  * @author Miguel Coutada
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
-public class SQL99TypeConverter implements TypeConverter {
+public class SQL2003TypeConverter implements TypeConverter {
   private static int getCLOBMinimum() {
     return 65535;
   }
@@ -93,8 +93,6 @@ public class SQL99TypeConverter implements TypeConverter {
       type = new SimpleTypeNumericApproximate(53);
     } else if (sqlStandardType.equals("BIT")) {
       type = new SimpleTypeBoolean();
-    } else if (sqlStandardType.startsWith("BIT VARYING")) {
-      type = new SimpleTypeBinary(getLength(sqlStandardType));
     } else if (sqlStandardType.startsWith("BIT")) {
       if (getLength(sqlStandardType) == 1) {
         type = new SimpleTypeBoolean();

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/metadata/typeConverter/TypeConverterFactory.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/metadata/typeConverter/TypeConverterFactory.java
@@ -5,11 +5,19 @@ package com.databasepreservation.modules.siard.in.metadata.typeConverter;
  */
 public class TypeConverterFactory {
   private static TypeConverter sql99;
+  private static TypeConverter sql2003;
 
   public static TypeConverter getSQL99TypeConverter() {
     if (sql99 == null) {
       sql99 = new SQL99TypeConverter();
     }
     return sql99;
+  }
+
+  public static TypeConverter getSQL2003TypeConverter() {
+    if (sql2003 == null) {
+      sql2003 = new SQL2003TypeConverter();
+    }
+    return sql2003;
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/sqlServer/in/SQLServerJDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/sqlServer/in/SQLServerJDBCImportModule.java
@@ -142,6 +142,7 @@ public class SQLServerJDBCImportModule extends JDBCImportModule {
       type = new SimpleTypeBinary();
     }
     type.setSql99TypeName("BINARY LARGE OBJECT");
+    type.setSql2003TypeName("BINARY LARGE OBJECT");
     return type;
   }
 

--- a/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
@@ -164,14 +164,17 @@ public class SiardTest {
 
     columns_table11.get(0).getType().setOriginalTypeName("int", 10, 0);
     columns_table11.get(0).getType().setSql99TypeName("INTEGER");
+    columns_table11.get(0).getType().setSql2003TypeName("INTEGER");
     columns_table11.get(0).getType().setDescription("col111 description");
 
     columns_table11.get(1).getType().setOriginalTypeName("bool");
     columns_table11.get(1).getType().setSql99TypeName("BOOLEAN");
+    columns_table11.get(1).getType().setSql2003TypeName("BOOLEAN");
     columns_table11.get(0).getType().setDescription("col112 description");
 
     columns_table11.get(2).getType().setOriginalTypeName("decimal", 5, 2);
-    columns_table11.get(2).getType().setSql99TypeName("DECIMAL(5,2)");
+    columns_table11.get(2).getType().setSql99TypeName("DECIMAL",5,2);
+    columns_table11.get(2).getType().setSql2003TypeName("DECIMAL",5,2);
     columns_table11.get(2).getType().setDescription("col113 description");
 
     // create columns for second table
@@ -191,14 +194,17 @@ public class SiardTest {
 
     columns_table12.get(0).getType().setOriginalTypeName("int", 10, 0);
     columns_table12.get(0).getType().setSql99TypeName("INTEGER");
+    columns_table12.get(0).getType().setSql2003TypeName("INTEGER");
     columns_table12.get(0).getType().setDescription("col121 description");
 
     columns_table12.get(1).getType().setOriginalTypeName("int", 10, 0);
     columns_table12.get(1).getType().setSql99TypeName("INTEGER");
+    columns_table12.get(1).getType().setSql2003TypeName("INTEGER");
     columns_table12.get(1).getType().setDescription("col122 description");
 
     columns_table12.get(2).getType().setOriginalTypeName("VARCHAR", 250);
-    columns_table12.get(2).getType().setSql99TypeName("CHARACTER VARYING(250)");
+    columns_table12.get(2).getType().setSql99TypeName("CHARACTER VARYING",250);
+    columns_table12.get(2).getType().setSql2003TypeName("CHARACTER VARYING",250);
     ((SimpleTypeString) columns_table12.get(2).getType()).setLength(250);
     ((SimpleTypeString) columns_table12.get(2).getType()).setLengthVariable(true);
     // TODO:
@@ -206,7 +212,8 @@ public class SiardTest {
     columns_table12.get(2).getType().setDescription("col123 description");
 
     columns_table12.get(3).getType().setOriginalTypeName("VARCHAR", 230);
-    columns_table12.get(3).getType().setSql99TypeName("CHARACTER VARYING(230)");
+    columns_table12.get(3).getType().setSql99TypeName("CHARACTER VARYING",230);
+    columns_table12.get(3).getType().setSql2003TypeName("CHARACTER VARYING",230);
     ((SimpleTypeString) columns_table12.get(3).getType()).setLength(230);
     ((SimpleTypeString) columns_table12.get(3).getType()).setLengthVariable(true);
     // TODO:
@@ -215,13 +222,17 @@ public class SiardTest {
 
     columns_table12.get(4).getType().setOriginalTypeName("BLOB");
     // TODO: columns_table12.get(4).getType().setSql99TypeName("BLOB");
+    // columns_table12.get(4).getType().setSql2003TypeName("BLOB");
     columns_table12.get(4).getType().setSql99TypeName("BINARY LARGE OBJECT");
+    columns_table12.get(4).getType().setSql2003TypeName("BINARY LARGE OBJECT");
     columns_table12.get(4).getType().setDescription("col125 description");
     columns_table12.get(4).setNillable(false);
 
     // columns_table12.get(5).getType().setOriginalTypeName("TEXT");
     // columns_table12.get(5).getType().setSql99TypeName("BINARY LARGE OBJECT");
+    // columns_table12.get(5).getType().setSql2003TypeName("BINARY LARGE OBJECT");
     // //TODO: columns_table12.get(5).getType().setSql99TypeName("CLOB");
+    // columns_table12.get(5).getType().setSql2003TypeName("CLOB");
     // columns_table12.get(5).getType().setDescription("col126 description");
 
     // schema02
@@ -235,14 +246,17 @@ public class SiardTest {
 
     columns_table21.get(0).getType().setOriginalTypeName("int", 10, 0);
     columns_table21.get(0).getType().setSql99TypeName("INTEGER");
+    columns_table21.get(0).getType().setSql2003TypeName("INTEGER");
     columns_table21.get(0).getType().setDescription("col211 description");
 
     columns_table21.get(1).getType().setOriginalTypeName("bool");
     columns_table21.get(1).getType().setSql99TypeName("BOOLEAN");
+    columns_table21.get(1).getType().setSql2003TypeName("BOOLEAN");
     columns_table21.get(0).getType().setDescription("col212 description");
 
     columns_table21.get(2).getType().setOriginalTypeName("decimal", 5, 2);
-    columns_table21.get(2).getType().setSql99TypeName("DECIMAL(5,2)");
+    columns_table21.get(2).getType().setSql99TypeName("DECIMAL",5,2);
+    columns_table21.get(2).getType().setSql2003TypeName("DECIMAL",5,2);
     columns_table21.get(2).getType().setDescription("col213 description");
 
     // create columns for second table
@@ -257,14 +271,17 @@ public class SiardTest {
 
     columns_table22.get(0).getType().setOriginalTypeName("int", 10, 0);
     columns_table22.get(0).getType().setSql99TypeName("INTEGER");
+    columns_table22.get(0).getType().setSql2003TypeName("INTEGER");
     columns_table22.get(0).getType().setDescription("col221 description");
 
     columns_table22.get(1).getType().setOriginalTypeName("int", 10, 0);
     columns_table22.get(1).getType().setSql99TypeName("INTEGER");
+    columns_table22.get(1).getType().setSql2003TypeName("INTEGER");
     columns_table22.get(1).getType().setDescription("col222 description");
 
     columns_table22.get(2).getType().setOriginalTypeName("VARCHAR", 250);
-    columns_table22.get(2).getType().setSql99TypeName("CHARACTER VARYING(250)");
+    columns_table22.get(2).getType().setSql99TypeName("CHARACTER VARYING",250);
+    columns_table22.get(2).getType().setSql2003TypeName("CHARACTER VARYING",250);
     ((SimpleTypeString) columns_table22.get(2).getType()).setLength(250);
     ((SimpleTypeString) columns_table22.get(2).getType()).setLengthVariable(true);
     // TODO:
@@ -272,7 +289,8 @@ public class SiardTest {
     columns_table22.get(2).getType().setDescription("col223 description");
 
     columns_table22.get(3).getType().setOriginalTypeName("VARCHAR", 230);
-    columns_table22.get(3).getType().setSql99TypeName("CHARACTER VARYING(230)");
+    columns_table22.get(3).getType().setSql99TypeName("CHARACTER VARYING",230);
+    columns_table22.get(3).getType().setSql2003TypeName("CHARACTER VARYING",230);
     ((SimpleTypeString) columns_table22.get(3).getType()).setLength(230);
     ((SimpleTypeString) columns_table22.get(3).getType()).setLengthVariable(true);
     // TODO:
@@ -347,7 +365,8 @@ public class SiardTest {
     param01.setMode("some mode 1");
     param01.setType(new SimpleTypeString(50, false));
     param01.getType().setOriginalTypeName("VARCHAR", 50);
-    param01.getType().setSql99TypeName("CHARACTER VARYING(50)");
+    param01.getType().setSql99TypeName("CHARACTER VARYING",50);
+    param01.getType().setSql2003TypeName("CHARACTER VARYING",50);
     ((SimpleTypeString) param01.getType()).setLength(50);
     ((SimpleTypeString) param01.getType()).setLengthVariable(true);
     // TODO: ((SimpleTypeString)param01.getType()).setCharset("UTF-8");
@@ -361,6 +380,7 @@ public class SiardTest {
     param02.setType(new SimpleTypeNumericExact());
     // TODO: param02.getType().setOriginalTypeName("int", 10, 0);
     param02.getType().setSql99TypeName("INTEGER");
+    param02.getType().setSql2003TypeName("INTEGER");
     // TODO: param02.getType().setDescription("param02 description");
     param02.setDescription("the second param");
 

--- a/dbptk-model/src/main/java/com/databasepreservation/model/structure/type/Type.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/model/structure/type/Type.java
@@ -21,6 +21,8 @@ public abstract class Type {
 
   private String sql99TypeName;
 
+  private String sql2003TypeName;
+
   // using the empty constructor is not advised
   protected Type() {
   }
@@ -114,6 +116,47 @@ public abstract class Type {
    */
   public void setSql99TypeName(String typeName, int originalColumnSize) {
     this.sql99TypeName = String.format("%s(%d)", typeName, originalColumnSize);
+  }
+
+  /**
+   * @return The name of the SQL2003 normalized type. null if not applicable
+   */
+  public String getSql2003TypeName() {
+
+    if (StringUtils.isBlank(sql2003TypeName)) {
+      logger.warn("SQL2003 type is not defined for type " + this.toString());
+    }
+    return sql2003TypeName;
+  }
+
+  /**
+   * @param sql2003TypeName
+   *          the name of the original type, null if not applicable
+   */
+  public void setSql2003TypeName(String sql2003TypeName) {
+    this.sql2003TypeName = sql2003TypeName;
+  }
+
+  /**
+   * @param typeName
+   *          The name of the original type
+   * @param originalColumnSize
+   *          Original column size
+   * @param originalDecimalDigits
+   *          Original decimal digits amount
+   */
+  public void setSql2003TypeName(String typeName, int originalColumnSize, int originalDecimalDigits) {
+    this.sql2003TypeName = String.format("%s(%d,%d)", typeName, originalColumnSize, originalDecimalDigits);
+  }
+
+  /**
+   * @param typeName
+   *          The name of the original type
+   * @param originalColumnSize
+   *          Original column size
+   */
+  public void setSql2003TypeName(String typeName, int originalColumnSize) {
+    this.sql2003TypeName = String.format("%s(%d)", typeName, originalColumnSize);
   }
 
   /**


### PR DESCRIPTION
SIARD2 uses SQL2003 standard, so it has been added.
SIARD1 still uses SQL99 standard.
This fixes issues #78 and #89

Some SQL99 types are now fixed.