### PR TITLE
Some fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ log/
 dbptk-app.log
 exported-dbs/
 
-
+**/pom.xml.versionsBackup
 
 test-output/
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -636,7 +636,7 @@ public class JDBCImportModule implements DatabaseImportModule {
       // String tableName = rs.getString(3);
       // 4. Column name
       String columnName = rs.getString(4);
-      cLogMessage.append("Column name: " + columnName + "\n");
+      //cLogMessage.append("Column name: " + columnName + "\n");
       // 5. SQL type from java.sql.Types
       int dataType = rs.getInt(5);
       cLogMessage.append("Data type: " + dataType + "\n");
@@ -716,10 +716,12 @@ public class JDBCImportModule implements DatabaseImportModule {
         numPrecRadix);
 
       cLogMessage.append("Calculated type: ").append(columnType.getClass().getSimpleName()).append("\n");
-      logger.trace(cLogMessage);
 
       ColumnStructure column = getColumnStructure(tableName, columnName, columnType, isNullable, index, remarks,
         defaultValue, isAutoIncrement);
+
+      cLogMessage.append("ColumnType hash: ").append(column.getType().hashCode()).append("\n");
+      logger.debug(cLogMessage);
 
       columns.add(column);
     }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -571,7 +571,9 @@ public class JDBCImportModule implements DatabaseImportModule {
           rs = getMetadata().getTablePrivileges(dbStructure.getName(), schema.getName(), table.getName());
         } catch (SQLException e) {
           logger
-            .error(
+            .warn("It was not possible to retrieve the list of all database permissions. Please ensure the current user has permissions to list all database permissions.");
+          logger
+            .debug(
               "It was not possible to retrieve the list of all database permissions. Please ensure the current user has permissions to list all database permissions.",
               e);
           break;

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -819,7 +819,9 @@ public class JDBCImportModule implements DatabaseImportModule {
         break;
       case Types.DECIMAL:
         type = getDecimalType(typeName, columnSize, decimalDigits, numPrecRadix);
-        type.setOriginalTypeName(typeName, columnSize, decimalDigits);
+        if(StringUtils.isBlank(type.getOriginalTypeName())) {
+          type.setOriginalTypeName(typeName, columnSize, decimalDigits);
+        }
         break;
       case Types.DOUBLE:
         type = getDoubleType(typeName, columnSize, decimalDigits, numPrecRadix);

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/SIARD1ContentExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/SIARD1ContentExportStrategy.java
@@ -356,7 +356,7 @@ public class SIARD1ContentExportStrategy implements ContentExportStrategy {
     int columnIndex = 1;
     for (ColumnStructure col : currentTable.getColumns()) {
       try {
-        String xsdType = sql99toXSDType.convert(col.getType());
+        String xsdType = Sql99toXSDType.convert(col.getType());
 
         xsdWriter.beginOpenTag("xs:element", 4);
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/SIARD2ContentExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/SIARD2ContentExportStrategy.java
@@ -359,7 +359,7 @@ public class SIARD2ContentExportStrategy implements ContentExportStrategy {
     int columnIndex = 1;
     for (ColumnStructure col : currentTable.getColumns()) {
       try {
-        String xsdType = sql99toXSDType.convert(col.getType());
+        String xsdType = Sql99toXSDType.convert(col.getType());
 
         xsdWriter.beginOpenTag("xs:element", 4);
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/Sql2003toXSDType.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/Sql2003toXSDType.java
@@ -1,0 +1,104 @@
+package com.databasepreservation.modules.siard.out.content;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.databasepreservation.model.exception.ModuleException;
+import com.databasepreservation.model.exception.UnknownTypeException;
+import com.databasepreservation.model.structure.type.ComposedTypeArray;
+import com.databasepreservation.model.structure.type.ComposedTypeStructure;
+import com.databasepreservation.model.structure.type.SimpleTypeBinary;
+import com.databasepreservation.model.structure.type.SimpleTypeBoolean;
+import com.databasepreservation.model.structure.type.SimpleTypeDateTime;
+import com.databasepreservation.model.structure.type.SimpleTypeNumericApproximate;
+import com.databasepreservation.model.structure.type.SimpleTypeNumericExact;
+import com.databasepreservation.model.structure.type.SimpleTypeString;
+import com.databasepreservation.model.structure.type.Type;
+import com.databasepreservation.model.structure.type.UnsupportedDataType;
+
+/**
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class Sql2003toXSDType {
+  private static final Map<String, String> sql2003toXSDconstant = new HashMap<String, String>();
+  private static final Map<String, String> sql2003toXSDregex = new HashMap<String, String>();
+
+  static {
+    // initialize sql2003 conversion tables
+
+    // direct mapping
+    sql2003toXSDconstant.put("BINARY LARGE OBJECT", "blobType");
+    sql2003toXSDconstant.put("BIT VARYING", "xs:hexBinary");
+    sql2003toXSDconstant.put("BIT", "xs:hexBinary");
+    sql2003toXSDconstant.put("BLOB", "blobType");
+    sql2003toXSDconstant.put("BOOLEAN", "xs:boolean");
+    sql2003toXSDconstant.put("CHARACTER LARGE OBJECT", "clobType");
+    sql2003toXSDconstant.put("CHARACTER VARYING", "xs:string");
+    sql2003toXSDconstant.put("CHARACTER", "xs:string");
+    sql2003toXSDconstant.put("CLOB", "clobType");
+    sql2003toXSDconstant.put("DATE", "xs:date");
+    sql2003toXSDconstant.put("DECIMAL", "xs:decimal");
+    sql2003toXSDconstant.put("DOUBLE PRECISION", "xs:float");
+    sql2003toXSDconstant.put("DOUBLE", "xs:float");
+    sql2003toXSDconstant.put("FLOAT", "xs:float");
+    sql2003toXSDconstant.put("INTEGER", "xs:integer");
+    sql2003toXSDconstant.put("NATIONAL CHARACTER LARGE OBJECT", "clobType");
+    sql2003toXSDconstant.put("NATIONAL CHARACTER VARYING", "xs:string");
+    sql2003toXSDconstant.put("NATIONAL CHARACTER", "xs:string");
+    sql2003toXSDconstant.put("NUMERIC", "xs:decimal");
+    sql2003toXSDconstant.put("REAL", "xs:float");
+    sql2003toXSDconstant.put("SMALLINT", "xs:integer");
+    sql2003toXSDconstant.put("TIME WITH TIME ZONE", "xs:time");
+    sql2003toXSDconstant.put("TIME", "xs:time");
+    sql2003toXSDconstant.put("TIMESTAMP WITH TIME ZONE", "xs:dateTime");
+    sql2003toXSDconstant.put("TIMESTAMP", "xs:dateTime");
+
+    // mapping using regex
+    sql2003toXSDregex.put("^BIT VARYING\\(\\d+\\)$", "xs:hexBinary");
+    sql2003toXSDregex.put("^BIT\\(\\d+\\)$", "xs:hexBinary");
+    sql2003toXSDregex.put("^CHARACTER VARYING\\(\\d+\\)$", "xs:string");
+    sql2003toXSDregex.put("^CHARACTER\\(\\d+\\)$", "xs:string");
+    sql2003toXSDregex.put("^DECIMAL\\(\\d+(,\\d+)?\\)$", "xs:decimal");
+    sql2003toXSDregex.put("^FLOAT\\(\\d+\\)$", "xs:float");
+    sql2003toXSDregex.put("^NUMERIC\\(\\d+(,\\d+)?\\)$", "xs:decimal");
+  }
+
+  public static String convert(Type type) throws ModuleException, UnknownTypeException {
+    String ret = null;
+    if (type instanceof SimpleTypeString || type instanceof SimpleTypeNumericExact
+      || type instanceof SimpleTypeNumericApproximate || type instanceof SimpleTypeBoolean
+      || type instanceof SimpleTypeDateTime || type instanceof SimpleTypeBinary) {
+
+      ret = convert(type.getSql2003TypeName());
+
+    } else if (type instanceof UnsupportedDataType) {
+      throw new ModuleException("Unsupported datatype: " + type.toString());
+    } else if (type instanceof ComposedTypeArray) {
+      throw new ModuleException("Not yet supported type: ARRAY");
+    } else if (type instanceof ComposedTypeStructure) {
+      throw new ModuleException("Not yet supported type: ROW");
+    } else {
+      throw new UnknownTypeException(type.toString());
+    }
+    return ret;
+  }
+
+  public static String convert(String sql2003Type) {
+    // try to find xsd corresponding to the sql2003 type in the constants
+    // conversion table
+    String ret = sql2003toXSDconstant.get(sql2003Type);
+
+    // if that failed, try to find xsd corresponding to the sql2003 type by using
+    // the regex in the regex conversion table
+    if (ret == null) {
+      for (Map.Entry<String, String> entry : sql2003toXSDregex.entrySet()) {
+        if (sql2003Type.matches(entry.getKey())) {
+          ret = entry.getValue();
+          break;
+        }
+      }
+    }
+
+    return ret;
+  }
+}

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/Sql99toXSDType.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/Sql99toXSDType.java
@@ -19,7 +19,7 @@ import com.databasepreservation.model.structure.type.UnsupportedDataType;
 /**
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
-public class sql99toXSDType {
+public class Sql99toXSDType {
   private static final Map<String, String> sql99toXSDconstant = new HashMap<String, String>();
   private static final Map<String, String> sql99toXSDregex = new HashMap<String, String>();
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
@@ -108,10 +108,8 @@ public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
       xsdSchema = schemaFactory.newSchema(new StreamSource(SiardArchive.class.getResourceAsStream(metadataPathStrategy
         .getXsdResourcePath(METADATA_RESOURCE_FILENAME))));
     } catch (SAXException e) {
-      throw new ModuleException(
-        "XSD file has errors: "
-          + SiardArchive.class.getResource(metadataPathStrategy.getXsdResourcePath(METADATA_RESOURCE_FILENAME))
-            .getPath(), e);
+      throw new ModuleException("XSD file has errors: "
+        + metadataPathStrategy.getXsdResourcePath(METADATA_RESOURCE_FILENAME), e);
     }
 
     SiardArchive xmlroot = jaxbSiardArchive(dbStructure);

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD1MetadataExportStrategy.java
@@ -540,6 +540,8 @@ public class SIARD1MetadataExportStrategy implements MetadataExportStrategy {
     }
 
     if (column.getType() != null) {
+      logger.debug("Saving type '" + column.getType().getOriginalTypeName() + "'(internal_id:"+column.getType().hashCode()+") as " + column.getType().getSql99TypeName());
+      logger.info("Saving type '" + column.getType().getOriginalTypeName() + "' as '" + column.getType().getSql99TypeName() + "'");
       columnType.setType(column.getType().getSql99TypeName());
       columnType.setTypeOriginal(column.getType().getOriginalTypeName());
     } else {

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD2MetadataExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD2MetadataExportStrategy.java
@@ -109,10 +109,8 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
       xsdSchema = schemaFactory.newSchema(new StreamSource(SiardArchive.class.getResourceAsStream(metadataPathStrategy
         .getXsdResourcePath(METADATA_RESOURCE_FILENAME))));
     } catch (SAXException e) {
-      throw new ModuleException(
-        "XSD file has errors: "
-          + SiardArchive.class.getResource(metadataPathStrategy.getXsdResourcePath(METADATA_RESOURCE_FILENAME))
-            .getPath(), e);
+      throw new ModuleException("XSD file has errors: "
+        + metadataPathStrategy.getXsdResourcePath(METADATA_RESOURCE_FILENAME), e);
     }
 
     SiardArchive xmlroot = jaxbSiardArchive(dbStructure);

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD2MetadataExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/SIARD2MetadataExportStrategy.java
@@ -14,6 +14,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import com.databasepreservation.modules.siard.out.content.Sql2003toXSDType;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.SAXException;
@@ -72,7 +73,6 @@ import com.databasepreservation.model.structure.ViewStructure;
 import com.databasepreservation.modules.siard.SIARDHelper;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.common.path.MetadataPathStrategy;
-import com.databasepreservation.modules.siard.out.content.sql99toXSDType;
 import com.databasepreservation.modules.siard.out.path.SIARD2ContentPathExportStrategy;
 import com.databasepreservation.modules.siard.out.write.WriteStrategy;
 import com.databasepreservation.utils.JodaUtils;
@@ -481,7 +481,7 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
     }
 
     if (parameter.getType() != null) {
-      parameterType.setType(parameter.getType().getSql99TypeName());
+      parameterType.setType(parameter.getType().getSql2003TypeName());
       parameterType.setTypeOriginal(parameter.getType().getOriginalTypeName());
     } else {
       throw new ModuleException("Error while exporting routine parameters: parameter type cannot be null");
@@ -561,7 +561,9 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
     }
 
     if (column.getType() != null) {
-      columnType.setType(column.getType().getSql99TypeName());
+      logger.debug("Saving type '" + column.getType().getOriginalTypeName() + "'(internal_id:"+column.getType().hashCode()+") as " + column.getType().getSql2003TypeName());
+      logger.info("Saving type '" + column.getType().getOriginalTypeName() + "' as '" + column.getType().getSql2003TypeName() + "'");
+      columnType.setType(column.getType().getSql2003TypeName());
       columnType.setTypeOriginal(column.getType().getOriginalTypeName());
     } else {
       throw new ModuleException("Error while exporting table structure: column type cannot be null");
@@ -584,8 +586,8 @@ public class SIARD2MetadataExportStrategy implements MetadataExportStrategy {
     // TODO: set fields related to lob and complex types
 
     // specific fields for lobs
-    String xsdTypeFromColumnSql99Type = sql99toXSDType.convert(column.getType().getSql99TypeName());
-    if (xsdTypeFromColumnSql99Type.equals("clobType") || xsdTypeFromColumnSql99Type.equals("blobType")) {
+    String xsdTypeFromColumnSql2003Type = Sql2003toXSDType.convert(column.getType().getSql2003TypeName());
+    if (xsdTypeFromColumnSql2003Type.equals("clobType") || xsdTypeFromColumnSql2003Type.equals("blobType")) {
       columnType.setFolder(contentPathStrategy.getColumnFolderName(columnIndex));
     }
 


### PR DESCRIPTION
About #105:
I was not able to reproduce the problem, but according to the log the ModuleException was not being thrown because there was a null pointer exception being thrown inside the `catch` block. The ModuleException should now be thrown.

About #95:
UX change.

About #106:
fixed it.

Better debug log:
Log now shows the type obtained from JDBC and the type it was mapped to in SQL99/SQL2003