### PR TITLE
Allows filtering by table name when exporting to SIARD 1 and 2

### DIFF
--- a/dbptk-core/src/main/java/com/databasepreservation/Main.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/Main.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 
+import com.databasepreservation.modules.listTables.ListTablesModuleFactory;
 import org.apache.commons.cli.ParseException;
 
 import com.databasepreservation.cli.CLI;
@@ -44,7 +45,7 @@ public class Main {
   private static final CustomLogger logger = CustomLogger.getLogger(Main.class);
 
   public static final DatabaseModuleFactory[] databaseModuleFactories = new DatabaseModuleFactory[] {
-    new JDBCModuleFactory(), new MsAccessUCanAccessModuleFactory(), new MySQLModuleFactory(),
+    new JDBCModuleFactory(), new ListTablesModuleFactory(),new MsAccessUCanAccessModuleFactory(), new MySQLModuleFactory(),
     new Oracle12cModuleFactory(), new PostgreSQLModuleFactory(), new SIARD1ModuleFactory(), new SIARD2ModuleFactory(),
     new SIARDDKModuleFactory(), new SQLServerJDBCModuleFactory()};
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/out/JDBCExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/jdbc/out/JDBCExportModule.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.databasepreservation.model.modules.ModuleSettings;
 import org.w3c.util.InvalidDateException;
 
 import com.databasepreservation.CustomLogger;
@@ -218,6 +219,16 @@ public class JDBCExportModule implements DatabaseExportModule {
       }
     }
     return statement;
+  }
+
+  /**
+   * Gets custom settings set by the export module that modify behaviour of
+   * the import module.
+   *
+   * @throws ModuleException
+   */
+  @Override public ModuleSettings getModuleSettings() throws ModuleException {
+    return new ModuleSettings();
   }
 
   @Override

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/listTables/ListTables.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/listTables/ListTables.java
@@ -1,0 +1,207 @@
+package com.databasepreservation.modules.listTables;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import com.databasepreservation.model.data.Row;
+import com.databasepreservation.model.exception.InvalidDataException;
+import com.databasepreservation.model.exception.ModuleException;
+import com.databasepreservation.model.exception.UnknownTypeException;
+import com.databasepreservation.model.modules.DatabaseExportModule;
+import com.databasepreservation.model.modules.ModuleSettings;
+import com.databasepreservation.model.structure.DatabaseStructure;
+import com.databasepreservation.model.structure.SchemaStructure;
+import com.databasepreservation.model.structure.TableStructure;
+
+/**
+ * Export module that produces a list of tables contained in the database. This
+ * list can then be used by other modules (e.g. the SIARD2 export module) to
+ * specify the tables that should be processed.
+ * 
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class ListTables implements DatabaseExportModule {
+  public static final String schemaTableSeparator = ".";
+
+  private DatabaseStructure dbStructure;
+  private SchemaStructure currentSchema;
+  private TableStructure currentTable;
+  private Path outputFile;
+  private OutputStream outStream;
+  private Writer out;
+
+  public ListTables(Path outputFile) {
+    this.outputFile = outputFile;
+  }
+
+  /**
+   * Gets custom settings set by the export module that modify behaviour of the
+   * import module.
+   *
+   * @throws ModuleException
+   */
+  @Override
+  public ModuleSettings getModuleSettings() throws ModuleException {
+    return new ModuleSettings() {
+      @Override
+      public boolean shouldFetchRows() {
+        return false;
+      }
+    };
+  }
+
+  /**
+   * Initialize the database, this will be the first method called
+   *
+   * @throws ModuleException
+   */
+  @Override
+  public void initDatabase() throws ModuleException {
+    try {
+      outStream = Files.newOutputStream(outputFile);
+      out = new OutputStreamWriter(outStream, "UTF8");
+
+    } catch (IOException e) {
+      throw new ModuleException("Could not create file " + outputFile.toAbsolutePath().toString(), e);
+    }
+  }
+
+  /**
+   * Set ignored schemas. Ignored schemas won't be exported. This method should
+   * be called before handleStructure. However, if not called it will be assumed
+   * there are not ignored schemas.
+   *
+   * @param ignoredSchemas
+   *          the set of schemas to ignored
+   */
+  @Override
+  public void setIgnoredSchemas(Set<String> ignoredSchemas) {
+    // nothing to do here
+  }
+
+  /**
+   * Handle the database structure. This method will called after
+   * setIgnoredSchemas.
+   *
+   * @param structure
+   *          the database structure
+   * @throws ModuleException
+   * @throws UnknownTypeException
+   */
+  @Override
+  public void handleStructure(DatabaseStructure structure) throws ModuleException, UnknownTypeException {
+    if (structure == null) {
+      throw new ModuleException("Database structure must not be null");
+    }
+
+    dbStructure = structure;
+  }
+
+  /**
+   * Prepare to handle the data of a new schema. This method will be called
+   * after handleStructure or handleDataCloseSchema.
+   *
+   * @param schemaName
+   *          the schema name
+   * @throws ModuleException
+   */
+  @Override
+  public void handleDataOpenSchema(String schemaName) throws ModuleException {
+    currentSchema = dbStructure.getSchemaByName(schemaName);
+
+    if (currentSchema == null) {
+      throw new ModuleException("Couldn't find schema with name: " + schemaName);
+    }
+  }
+
+  /**
+   * Prepare to handle the data of a new table. This method will be called after
+   * the handleDataOpenSchema, and before some calls to handleDataRow. If there
+   * are no rows in the table, then handleDataCloseTable is called after this
+   * method.
+   *
+   * @param tableId
+   *          the table id
+   * @throws ModuleException
+   */
+  @Override
+  public void handleDataOpenTable(String tableId) throws ModuleException {
+    try {
+      currentTable = dbStructure.lookupTableStructure(tableId);
+      if (currentTable == null) {
+        throw new ModuleException("Couldn't find table with id: " + tableId);
+      }
+
+      out.append(currentSchema.getName()).append(schemaTableSeparator).append(currentTable.getName()).append("\n");
+    } catch (IOException e) {
+      throw new ModuleException("Could not write to file (" + outputFile.toAbsolutePath().toString() + ")", e);
+    }
+  }
+
+  /**
+   * Handle a table row. This method will be called after the table was open and
+   * before it was closed, by row index order.
+   *
+   * @param row
+   *          the table row
+   * @throws InvalidDataException
+   * @throws ModuleException
+   */
+  @Override
+  public void handleDataRow(Row row) throws InvalidDataException, ModuleException {
+    // nothing to do
+  }
+
+  /**
+   * Finish handling the data of a table. This method will be called after all
+   * table rows for the table where requested to be handled.
+   *
+   * @param tableId
+   *          the table id
+   * @throws ModuleException
+   */
+  @Override
+  public void handleDataCloseTable(String tableId) throws ModuleException {
+    // nothing to do
+  }
+
+  /**
+   * Finish handling the data of a schema. This method will be called after all
+   * tables of the schema were requested to be handled.
+   *
+   * @param schemaName
+   *          the schema name
+   * @throws ModuleException
+   */
+  @Override
+  public void handleDataCloseSchema(String schemaName) throws ModuleException {
+    // nothing to do
+  }
+
+  /**
+   * Finish the database. This method will be called when all data was requested
+   * to be handled. This is the last method.
+   *
+   * @throws ModuleException
+   */
+  @Override
+  public void finishDatabase() throws ModuleException {
+    try {
+      out.close();
+    } catch (IOException e) {
+      throw new ModuleException("Could not close file writer stream (file: " + outputFile.toAbsolutePath().toString()
+        + ")", e);
+    }
+
+    try {
+      outStream.close();
+    } catch (IOException e) {
+      throw new ModuleException("Could not close file stream (file: " + outputFile.toAbsolutePath().toString() + ")", e);
+    }
+  }
+}

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/listTables/ListTablesModuleFactory.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/listTables/ListTablesModuleFactory.java
@@ -1,0 +1,75 @@
+package com.databasepreservation.modules.listTables;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.naming.OperationNotSupportedException;
+
+import com.databasepreservation.model.exception.LicenseNotAcceptedException;
+import com.databasepreservation.model.modules.DatabaseExportModule;
+import com.databasepreservation.model.modules.DatabaseImportModule;
+import com.databasepreservation.model.modules.DatabaseModuleFactory;
+import com.databasepreservation.model.parameters.Parameter;
+import com.databasepreservation.model.parameters.Parameters;
+
+/**
+ * Exposes an export module that produces a list of tables contained in the
+ * database. This list can then be used by other modules (e.g. the SIARD2 export
+ * module) to specify the tables that should be processed.
+ *
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class ListTablesModuleFactory implements DatabaseModuleFactory {
+  private static final Parameter file = new Parameter().shortName("f").longName("file")
+    .description("Path to output file that can be read by SIARD2 export module").hasArgument(true)
+    .setOptionalArgument(false).required(true);
+
+  @Override
+  public boolean producesImportModules() {
+    return false;
+  }
+
+  @Override
+  public boolean producesExportModules() {
+    return true;
+  }
+
+  @Override
+  public String getModuleName() {
+    return "list-tables";
+  }
+
+  @Override
+  public Map<String, Parameter> getAllParameters() {
+    HashMap<String, Parameter> parameterHashMap = new HashMap<String, Parameter>();
+    parameterHashMap.put(file.longName(), file);
+    return parameterHashMap;
+  }
+
+  @Override
+  public Parameters getImportModuleParameters() throws OperationNotSupportedException {
+    throw DatabaseModuleFactory.ExceptionBuilder.OperationNotSupportedExceptionForImportModule();
+  }
+
+  @Override
+  public Parameters getExportModuleParameters() throws OperationNotSupportedException {
+    return new Parameters(Arrays.asList(file), null);
+  }
+
+  @Override
+  public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters)
+    throws OperationNotSupportedException, LicenseNotAcceptedException {
+    throw DatabaseModuleFactory.ExceptionBuilder.OperationNotSupportedExceptionForImportModule();
+  }
+
+  @Override
+  public DatabaseExportModule buildExportModule(Map<Parameter, String> parameters)
+    throws OperationNotSupportedException, LicenseNotAcceptedException {
+    Path pFile = Paths.get(parameters.get(file));
+
+    return new ListTables(pFile);
+  }
+}

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD1ModuleFactory.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD1ModuleFactory.java
@@ -1,5 +1,6 @@
 package com.databasepreservation.modules.siard;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,6 +33,13 @@ public class SIARD1ModuleFactory implements DatabaseModuleFactory {
     .description("write human-readable XML").hasArgument(false).required(false).valueIfNotSet("false")
     .valueIfSet("true");
 
+  private static final Parameter tableFilter = new Parameter()
+    .shortName("tf")
+    .longName("table-filter")
+    .description(
+      "file with the list of tables that should be exported (this file can be created by the list-tables export module).")
+    .required(false).hasArgument(true).setOptionalArgument(false);
+
   @Override
   public boolean producesImportModules() {
     return true;
@@ -53,6 +61,7 @@ public class SIARD1ModuleFactory implements DatabaseModuleFactory {
     parameterHashMap.put(file.longName(), file);
     parameterHashMap.put(compress.longName(), compress);
     parameterHashMap.put(prettyPrintXML.longName(), prettyPrintXML);
+    parameterHashMap.put(tableFilter.longName(), tableFilter);
     return parameterHashMap;
   }
 
@@ -63,7 +72,7 @@ public class SIARD1ModuleFactory implements DatabaseModuleFactory {
 
   @Override
   public Parameters getExportModuleParameters() throws OperationNotSupportedException {
-    return new Parameters(Arrays.asList(file, compress, prettyPrintXML), null);
+    return new Parameters(Arrays.asList(file, compress, prettyPrintXML, tableFilter), null);
   }
 
   @Override
@@ -89,6 +98,11 @@ public class SIARD1ModuleFactory implements DatabaseModuleFactory {
       pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfSet());
     }
 
-    return new SIARD1ExportModule(Paths.get(pFile), pCompress, pPrettyPrintXML).getDatabaseHandler();
+    Path pTableFilter = null;
+    if (StringUtils.isNotBlank(parameters.get(tableFilter))) {
+      pTableFilter = Paths.get(parameters.get(tableFilter));
+    }
+
+    return new SIARD1ExportModule(Paths.get(pFile), pCompress, pPrettyPrintXML, pTableFilter).getDatabaseHandler();
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD2ModuleFactory.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/SIARD2ModuleFactory.java
@@ -1,5 +1,6 @@
 package com.databasepreservation.modules.siard;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,6 +44,13 @@ public class SIARD2ModuleFactory implements DatabaseModuleFactory {
     .description("write human-readable XML").hasArgument(false).required(false).valueIfNotSet("false")
     .valueIfSet("true");
 
+  private static final Parameter tableFilter = new Parameter()
+    .shortName("tf")
+    .longName("table-filter")
+    .description(
+      "file with the list of tables that should be exported (this file can be created by the list-tables export module).")
+    .required(false).hasArgument(true).setOptionalArgument(false);
+
   @Override
   public boolean producesImportModules() {
     return true;
@@ -64,6 +72,7 @@ public class SIARD2ModuleFactory implements DatabaseModuleFactory {
     parameterHashMap.put(file.longName(), file);
     parameterHashMap.put(compress.longName(), compress);
     parameterHashMap.put(prettyPrintXML.longName(), prettyPrintXML);
+    parameterHashMap.put(tableFilter.longName(), tableFilter);
     return parameterHashMap;
   }
 
@@ -74,7 +83,7 @@ public class SIARD2ModuleFactory implements DatabaseModuleFactory {
 
   @Override
   public Parameters getExportModuleParameters() throws OperationNotSupportedException {
-    return new Parameters(Arrays.asList(file, compress, prettyPrintXML), null);
+    return new Parameters(Arrays.asList(file, compress, prettyPrintXML, tableFilter), null);
   }
 
   @Override
@@ -100,6 +109,11 @@ public class SIARD2ModuleFactory implements DatabaseModuleFactory {
       pPrettyPrintXML = Boolean.parseBoolean(prettyPrintXML.valueIfSet());
     }
 
-    return new SIARD2ExportModule(Paths.get(pFile), pCompress, pPrettyPrintXML).getDatabaseHandler();
+    Path pTableFilter = null;
+    if (StringUtils.isNotBlank(parameters.get(tableFilter))) {
+      pTableFilter = Paths.get(parameters.get(tableFilter));
+    }
+
+    return new SIARD2ExportModule(Paths.get(pFile), pCompress, pPrettyPrintXML, pTableFilter).getDatabaseHandler();
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
@@ -25,10 +25,12 @@ public class SIARD1ExportModule {
   private final SIARDArchiveContainer mainContainer;
   private final WriteStrategy writeStrategy;
 
+  private final Path tableFilter;
+
   private MetadataExportStrategy metadataStrategy;
   private ContentExportStrategy contentStrategy;
 
-  public SIARD1ExportModule(Path siardPackage, boolean compressZip, boolean prettyXML) {
+  public SIARD1ExportModule(Path siardPackage, boolean compressZip, boolean prettyXML, Path tableFilter) {
     contentPathStrategy = new SIARD1ContentPathExportStrategy();
     metadataPathStrategy = new SIARD1MetadataPathStrategy();
     if (compressZip) {
@@ -40,9 +42,11 @@ public class SIARD1ExportModule {
 
     metadataStrategy = new SIARD1MetadataExportStrategy(metadataPathStrategy, contentPathStrategy);
     contentStrategy = new SIARD1ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer, prettyXML);
+
+    this.tableFilter = tableFilter;
   }
 
   public DatabaseExportModule getDatabaseHandler() {
-    return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy, null);
+    return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy, tableFilter);
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD1ExportModule.java
@@ -43,6 +43,6 @@ public class SIARD1ExportModule {
   }
 
   public DatabaseExportModule getDatabaseHandler() {
-    return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy);
+    return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy, null);
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARD2ExportModule.java
@@ -24,10 +24,12 @@ public class SIARD2ExportModule {
   private final SIARDArchiveContainer mainContainer;
   private final WriteStrategy writeStrategy;
 
+  private final Path tableFilter;
+
   private MetadataExportStrategy metadataStrategy;
   private ContentExportStrategy contentStrategy;
 
-  public SIARD2ExportModule(Path siardPackage, boolean compressZip, boolean prettyXML) {
+  public SIARD2ExportModule(Path siardPackage, boolean compressZip, boolean prettyXML, Path tableFilter) {
     contentPathStrategy = new SIARD2ContentPathExportStrategy();
     metadataPathStrategy = new SIARD2MetadataPathStrategy();
     if (compressZip) {
@@ -39,9 +41,11 @@ public class SIARD2ExportModule {
 
     metadataStrategy = new SIARD2MetadataExportStrategy(metadataPathStrategy, contentPathStrategy);
     contentStrategy = new SIARD2ContentExportStrategy(contentPathStrategy, writeStrategy, mainContainer, prettyXML);
+
+    this.tableFilter = tableFilter;
   }
 
   public DatabaseExportModule getDatabaseHandler() {
-    return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy);
+    return new SIARDExportDefault(contentStrategy, mainContainer, writeStrategy, metadataStrategy, tableFilter);
   }
 }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDDKDatabaseExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDDKDatabaseExportModule.java
@@ -29,7 +29,7 @@ public class SIARDDKDatabaseExportModule extends SIARDExportDefault {
 
   public SIARDDKDatabaseExportModule(SIARDDKExportModule siarddkExportModule) {
     super(siarddkExportModule.getContentExportStrategy(), siarddkExportModule.getMainContainer(), siarddkExportModule
-      .getWriteStrategy(), siarddkExportModule.getMetadataExportStrategy());
+      .getWriteStrategy(), siarddkExportModule.getMetadataExportStrategy(), null);
 
     this.siarddkExportModule = siarddkExportModule;
   }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDExportDefault.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDExportDefault.java
@@ -1,15 +1,29 @@
 package com.databasepreservation.modules.siard.out.output;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 import com.databasepreservation.model.data.Row;
 import com.databasepreservation.model.exception.InvalidDataException;
 import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.exception.UnknownTypeException;
 import com.databasepreservation.model.modules.DatabaseExportModule;
+import com.databasepreservation.model.modules.ModuleSettings;
 import com.databasepreservation.model.structure.DatabaseStructure;
 import com.databasepreservation.model.structure.SchemaStructure;
 import com.databasepreservation.model.structure.TableStructure;
+import com.databasepreservation.modules.listTables.ListTables;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.out.content.ContentExportStrategy;
 import com.databasepreservation.modules.siard.out.metadata.MetadataExportStrategy;
@@ -23,17 +37,69 @@ public class SIARDExportDefault implements DatabaseExportModule {
   private final WriteStrategy writeStrategy;
   private final MetadataExportStrategy metadataStrategy;
   private final ContentExportStrategy contentStrategy;
+  private final Path tableFilter;
+
+  private ModuleSettings moduleSettings = null;
 
   private DatabaseStructure dbStructure;
   private SchemaStructure currentSchema;
   private TableStructure currentTable;
 
   public SIARDExportDefault(ContentExportStrategy contentStrategy, SIARDArchiveContainer mainContainer,
-    WriteStrategy writeStrategy, MetadataExportStrategy metadataStrategy) {
+    WriteStrategy writeStrategy, MetadataExportStrategy metadataStrategy, Path tableFilter) {
     this.contentStrategy = contentStrategy;
     this.mainContainer = mainContainer;
     this.writeStrategy = writeStrategy;
     this.metadataStrategy = metadataStrategy;
+    this.tableFilter = tableFilter;
+  }
+
+  /**
+   * Gets custom settings set by the export module that modify behaviour of the
+   * import module.
+   *
+   * @throws ModuleException
+   */
+  @Override
+  public ModuleSettings getModuleSettings() throws ModuleException {
+    if (moduleSettings != null) {
+      return moduleSettings;
+    }
+
+    if (tableFilter == null) {
+      moduleSettings = new ModuleSettings();
+    } else {
+      try {
+        // attempt to get a table list from the file at tableFilter and use that
+        // list as selectedTables in the ModuleSettings
+        InputStream inputStream = Files.newInputStream(tableFilter);
+        InputStreamReader inputStreamReader = new InputStreamReader(inputStream, "UTF8");
+        BufferedReader reader = new BufferedReader(inputStreamReader);
+
+        final HashSet<Pair<String, String>> selectedTables = new HashSet<>();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          if (StringUtils.isNotBlank(line)) {
+            if (StringUtils.countMatches(line, ListTables.schemaTableSeparator) != 1) {
+              throw new ModuleException("Malformed entry in table list: " + line);
+            }
+
+            String[] parts = line.split(Pattern.quote(ListTables.schemaTableSeparator));
+            selectedTables.add(new ImmutablePair<String, String>(parts[0], parts[1]));
+          }
+        }
+
+        moduleSettings = new ModuleSettings() {
+          @Override
+          public Set<Pair<String, String>> selectedTables() {
+            return selectedTables;
+          }
+        };
+      } catch (IOException e) {
+        throw new ModuleException("Could not read table list from file " + tableFilter.toAbsolutePath().toString(), e);
+      }
+    }
+    return moduleSettings;
   }
 
   @Override

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/sqlFile/out/SQLFileExportModule.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/sqlFile/out/SQLFileExportModule.java
@@ -28,6 +28,7 @@ import com.databasepreservation.model.exception.InvalidDataException;
 import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.exception.UnknownTypeException;
 import com.databasepreservation.model.modules.DatabaseExportModule;
+import com.databasepreservation.model.modules.ModuleSettings;
 import com.databasepreservation.model.structure.ColumnStructure;
 import com.databasepreservation.model.structure.DatabaseStructure;
 import com.databasepreservation.model.structure.ForeignKey;
@@ -212,6 +213,16 @@ public class SQLFileExportModule implements DatabaseExportModule {
     };
     new Thread(writerRunnable).start();
     escapeStringLiteral(bin, out);
+  }
+
+  /**
+   * Gets custom settings set by the export module that modify behaviour of
+   * the import module.
+   *
+   * @throws ModuleException
+   */
+  @Override public ModuleSettings getModuleSettings() throws ModuleException {
+    return new ModuleSettings();
   }
 
   @Override

--- a/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
@@ -528,7 +528,7 @@ public class SiardTest {
 
     switch (version) {
       case SIARD_1:
-        exporter = new SIARD1ExportModule(tmpFile, true, false).getDatabaseHandler();
+        exporter = new SIARD1ExportModule(tmpFile, true, false, null).getDatabaseHandler();
         break;
       case SIARD_2:
         exporter = new SIARD2ExportModule(tmpFile, true, false, null).getDatabaseHandler();

--- a/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/testing/integration/siard/SiardTest.java
@@ -531,7 +531,7 @@ public class SiardTest {
         exporter = new SIARD1ExportModule(tmpFile, true, false).getDatabaseHandler();
         break;
       case SIARD_2:
-        exporter = new SIARD2ExportModule(tmpFile, true, false).getDatabaseHandler();
+        exporter = new SIARD2ExportModule(tmpFile, true, false, null).getDatabaseHandler();
         break;
     }
 

--- a/dbptk-model/src/main/java/com/databasepreservation/model/modules/DatabaseExportModule.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/model/modules/DatabaseExportModule.java
@@ -13,8 +13,17 @@ import com.databasepreservation.model.structure.DatabaseStructure;
 
 /**
  * @author Luis Faria
+ * @author Bruno Ferreira <bferreira@keep.pt>
  */
 public interface DatabaseExportModule {
+  /**
+   * Gets custom settings set by the export module that modify behaviour of
+   * the import module.
+   * 
+   * @throws ModuleException
+   */
+  ModuleSettings getModuleSettings() throws ModuleException;
+
   /**
    * Initialize the database, this will be the first method called
    *

--- a/dbptk-model/src/main/java/com/databasepreservation/model/modules/ModuleSettings.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/model/modules/ModuleSettings.java
@@ -1,0 +1,64 @@
+package com.databasepreservation.model.modules;
+
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Custom settings set by the export module that modify behaviour of the import
+ * module.
+ *
+ * The suggested way to use this class is to create an anonymous class and
+ * override the desired settings.
+ * 
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class ModuleSettings {
+  public ModuleSettings() {
+  }
+
+  /**
+   * Should the import module retrieve table rows and call handleRow(...) on the
+   * export module for each row.
+   * 
+   * @return the setting choice
+   */
+  public boolean shouldFetchRows() {
+    return true;
+  }
+
+  /**
+   * Set of tables that should be processed. If null is returned all tables
+   * should be processed.
+   * 
+   * @return The set of tables to process, each entry should be a pair like
+   *         Pair(schemaName,tableName). Return `null` to process all tables. An
+   *         empty set ignores all tables.
+   */
+  public Set<Pair<String, String>> selectedTables() {
+    return null;
+  }
+
+  /**
+   * Use the selectedTables set to determine if a table is selected.
+   *
+   * @param schemaName the schema name
+   * @param tableName the table name
+   * @return true if the table is selected, false otherwise
+   */
+  public boolean isSelectedTable(String schemaName, String tableName) {
+    if (selectedTables() == null) {
+      return true;
+    }
+
+    for (Pair<String, String> pair : selectedTables()) {
+      String pairSchemaName = pair.getLeft();
+      String pairTableName = pair.getRight();
+
+      if (pairSchemaName.equals(schemaName) && pairTableName.equals(tableName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
* adds an export module that produces a list of tables in a database
* adds a command line parameter to SIARD 1 and 2 that allows specifying a file containing a list of tables to export (all other tables will be ignored)

The workflow for using the filter feature would be to import from DBMS and export to list-tables module. Then import from DBMS and export to SIARD 1 or 2.