### PR TITLE
Better handling of LOBs in postgresql import

### DIFF
--- a/dbptk-bindings/pom.xml
+++ b/dbptk-bindings/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/dbptk-core/pom.xml
+++ b/dbptk-core/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-core</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-core</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
     <properties>

--- a/dbptk-model/pom.xml
+++ b/dbptk-model/pom.xml
@@ -5,12 +5,12 @@
     <name>dbptk-model</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-model</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/dbptk-model/src/main/java/com/databasepreservation/model/Reporter.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/model/Reporter.java
@@ -201,18 +201,17 @@ public class Reporter {
     }
   }
 
-  public static void cellProcessingUsedNull(TableStructure table, ColumnStructure column, long rowIndex,
-    Throwable exception) {
+  public static void cellProcessingUsedNull(String tableId, String columnName, long rowIndex, Throwable exception) {
     conversionProblemsCounter++;
     StringBuilder message = new StringBuilder("Problem processing cell value and NULL was used instead, ");
 
-    if (table != null && column != null) {
+    if (StringUtils.isNotBlank(tableId) && StringUtils.isNotBlank(columnName)) {
       message.append("in table ");
-      appendAsCode(message, table.getId()).append(", in column ");
-      appendAsCode(message, column.getName()).append(", ");
-    } else if (column != null) {
+      appendAsCode(message, tableId).append(", in column ");
+      appendAsCode(message, columnName).append(", ");
+    } else if (StringUtils.isNotBlank(columnName)) {
       message.append("in column ");
-      appendAsCode(message, column.getName()).append(", ");
+      appendAsCode(message, columnName).append(", ");
     } else {
       message.append("in an unidentified table and column, ");
     }
@@ -220,6 +219,11 @@ public class Reporter {
 
     report(message);
     LOGGER.debug("cellProcessingUsedNull, message: " + message, exception);
+  }
+
+  public static void cellProcessingUsedNull(TableStructure table, ColumnStructure column, long rowIndex,
+    Throwable exception) {
+    cellProcessingUsedNull(table.getId(), column.getName(), rowIndex, exception);
   }
 
   public static void rowProcessingUsedNull(TableStructure table, long rowIndex, Throwable exception) {

--- a/dbptk-modules/dbptk-module-db2/pom.xml
+++ b/dbptk-modules/dbptk-module-db2/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-db2</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-db2</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-jdbc/pom.xml
+++ b/dbptk-modules/dbptk-module-jdbc/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-jdbc</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-jdbc</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-jdbc/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
+++ b/dbptk-modules/dbptk-module-jdbc/src/main/java/com/databasepreservation/modules/jdbc/in/JDBCImportModule.java
@@ -1180,67 +1180,73 @@ public class JDBCImportModule implements DatabaseImportModule {
     ResultSet rawData) throws SQLException, InvalidDataException, ModuleException {
     Cell cell;
     String id = tableName + "." + columnName + "." + rowIndex;
-    if (cellType instanceof ComposedTypeArray) {
-      ComposedTypeArray composedTypeArray = (ComposedTypeArray) cellType;
-      Array array = rawData.getArray(columnName);
-      LOGGER.debug("Parsing array of subtype " + composedTypeArray.getElementType().getClass().getSimpleName());
-      List<Cell> cells = parseArray(id, array);
-      cell = new ComposedCell(id, cells);
-    } else if (cellType instanceof ComposedTypeStructure) {
-      cell = rawToCellComposedTypeStructure(id, columnName, cellType, rawData);
-    } else if (cellType instanceof SimpleTypeBoolean) {
-      boolean booleanValue = rawData.getBoolean(columnName);
-      boolean wasNull = rawData.wasNull();
-      if (wasNull) {
-        cell = new NullCell(id);
-      } else {
-        cell = new SimpleCell(id, booleanValue ? "true" : "false");
-      }
 
-    } else if (cellType instanceof SimpleTypeNumericApproximate) {
-      cell = rawToCellSimpleTypeNumericApproximate(id, columnName, cellType, rawData);
-    } else if (cellType instanceof SimpleTypeDateTime) {
-      cell = rawToCellSimpleTypeDateTime(id, columnName, cellType, rawData);
-    } else if (cellType instanceof SimpleTypeBinary) {
-      cell = rawToCellSimpleTypeBinary(id, columnName, cellType, rawData);
-    } else if (cellType instanceof UnsupportedDataType) {
-      try {
-        cell = new SimpleCell(id, rawData.getString(columnName));
-      } catch (SQLException e) {
-        LOGGER.debug("Could not export cell of unsupported datatype: OTHER", e);
-        cell = new NullCell(id);
-      }
-    } else if (cellType instanceof SimpleTypeNumericExact) {
-      cell = rawToCellSimpleTypeNumericExact(id, columnName, cellType, rawData);
-    } else {
-      try {
-        if (rawData.getString(columnName) == null) {
+    try {
+      if (cellType instanceof ComposedTypeArray) {
+        ComposedTypeArray composedTypeArray = (ComposedTypeArray) cellType;
+        Array array = rawData.getArray(columnName);
+        LOGGER.debug("Parsing array of subtype " + composedTypeArray.getElementType().getClass().getSimpleName());
+        List<Cell> cells = parseArray(id, array);
+        cell = new ComposedCell(id, cells);
+      } else if (cellType instanceof ComposedTypeStructure) {
+        cell = rawToCellComposedTypeStructure(id, columnName, cellType, rawData);
+      } else if (cellType instanceof SimpleTypeBoolean) {
+        boolean booleanValue = rawData.getBoolean(columnName);
+        boolean wasNull = rawData.wasNull();
+        if (wasNull) {
           cell = new NullCell(id);
         } else {
-          cell = new SimpleCell(id, rawData.getString(columnName));
+          cell = new SimpleCell(id, booleanValue ? "true" : "false");
         }
-      } catch (SQLException e) {
-        LOGGER.debug("Could not export cell of unknown/undefined datatype", e);
-        cell = new NullCell(id);
-      } catch (NoClassDefFoundError e) {
+
+      } else if (cellType instanceof SimpleTypeNumericApproximate) {
+        cell = rawToCellSimpleTypeNumericApproximate(id, columnName, cellType, rawData);
+      } else if (cellType instanceof SimpleTypeDateTime) {
+        cell = rawToCellSimpleTypeDateTime(id, columnName, cellType, rawData);
+      } else if (cellType instanceof SimpleTypeBinary) {
+        cell = rawToCellSimpleTypeBinary(id, columnName, cellType, rawData);
+      } else if (cellType instanceof UnsupportedDataType) {
         try {
-          Object[] aStruct = ((Struct) rawData.getObject(columnName)).getAttributes();
-
-          StringBuilder value = new StringBuilder("(");
-          String separator = "";
-          for (Object o : aStruct) {
-            value.append(separator).append(o.toString());
-            separator = ",";
-          }
-          value.append(")");
-
-          cell = new SimpleCell(id, value.toString());
-        } catch (SQLException e1) {
-          LOGGER.debug("No Class Def Found when trying to getString", e);
-          LOGGER.debug("Could not export cell of unknown/undefined datatype", e1);
+          cell = new SimpleCell(id, rawData.getString(columnName));
+        } catch (SQLException e) {
+          LOGGER.debug("Could not export cell of unsupported datatype: OTHER", e);
           cell = new NullCell(id);
         }
+      } else if (cellType instanceof SimpleTypeNumericExact) {
+        cell = rawToCellSimpleTypeNumericExact(id, columnName, cellType, rawData);
+      } else {
+        try {
+          if (rawData.getString(columnName) == null) {
+            cell = new NullCell(id);
+          } else {
+            cell = new SimpleCell(id, rawData.getString(columnName));
+          }
+        } catch (SQLException e) {
+          LOGGER.debug("Could not export cell of unknown/undefined datatype", e);
+          cell = new NullCell(id);
+        } catch (NoClassDefFoundError e) {
+          try {
+            Object[] aStruct = ((Struct) rawData.getObject(columnName)).getAttributes();
+
+            StringBuilder value = new StringBuilder("(");
+            String separator = "";
+            for (Object o : aStruct) {
+              value.append(separator).append(o.toString());
+              separator = ",";
+            }
+            value.append(")");
+
+            cell = new SimpleCell(id, value.toString());
+          } catch (SQLException e1) {
+            LOGGER.debug("No Class Def Found when trying to getString", e);
+            LOGGER.debug("Could not export cell of unknown/undefined datatype", e1);
+            cell = new NullCell(id);
+          }
+        }
       }
+    }catch(Exception e){
+      cell = new NullCell(id);
+      Reporter.cellProcessingUsedNull(tableName, columnName, rowIndex, e);
     }
     return cell;
   }
@@ -1518,6 +1524,7 @@ public class JDBCImportModule implements DatabaseImportModule {
                 }
               }
             }
+            tableRawData.close();
           }
           LOGGER.info("Total of " + nRows + " row(s) processed");
           getDatabaseStructure().lookupTableStructure(table.getId()).setRows(nRows);

--- a/dbptk-modules/dbptk-module-list-tables/pom.xml
+++ b/dbptk-modules/dbptk-module-list-tables/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-list-tables</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-list-tables</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-ms-access/pom.xml
+++ b/dbptk-modules/dbptk-module-ms-access/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-ms-access</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-ms-access</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-mysql/pom.xml
+++ b/dbptk-modules/dbptk-module-mysql/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-mysql</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-mysql</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-odbc/pom.xml
+++ b/dbptk-modules/dbptk-module-odbc/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-odbc</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-odbc</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-oracle/pom.xml
+++ b/dbptk-modules/dbptk-module-oracle/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-oracle</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-oracle</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-postgresql/pom.xml
+++ b/dbptk-modules/dbptk-module-postgresql/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4.1208.jre7</version>
+            <version>9.4.1212.jre7</version>
         </dependency>
     </dependencies>
 </project>

--- a/dbptk-modules/dbptk-module-postgresql/pom.xml
+++ b/dbptk-modules/dbptk-module-postgresql/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-postgresql</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-postgresql</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
+++ b/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
@@ -24,6 +24,7 @@ import org.postgresql.core.Oid;
 import org.postgresql.jdbc.PgResultSet;
 import org.postgresql.largeobject.LargeObject;
 import org.postgresql.largeobject.LargeObjectManager;
+import org.postgresql.util.PSQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,10 +170,32 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
 
     LOGGER.debug("query: " + query.toString());
 
+    // use a high fetchSize, reducing it if it proves to be too high
+    // since you are reading this, you might as well check if this related pull
+    // request https://github.com/pgjdbc/pgjdbc/pull/675 has already been merged
+    int fetchSize = 200;
     Statement st = getStatement();
-    st.setFetchSize(200);
-    ResultSet set = st.executeQuery(query.toString());
-    return set;
+    while (fetchSize > 0) {
+      st.setFetchSize(fetchSize);
+      try {
+        return st.executeQuery(query.toString());
+      } catch (PSQLException psqlException) {
+        if (psqlException.getCause() instanceof OutOfMemoryError) {
+          LOGGER.debug("FetchSize of {} resulted in out of memory", fetchSize, psqlException);
+          if (fetchSize > 1) {
+            fetchSize = 1;
+          } else {
+            fetchSize = 0;
+          }
+        } else {
+          throw psqlException;
+        }
+      }
+    }
+    Reporter.customMessage(this.getClass().getName(), "Could not retrieve all data from table '" + table.getId()
+      + "' due to insufficient memory.");
+    throw new ModuleException("Out of memory while trying to fetch table '" + table.getId()
+      + "' data. More information at www.database-preservation.com");
   }
 
   /**

--- a/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
+++ b/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
@@ -411,8 +411,12 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
         cell = new BinaryCell(id, binaryStream);
       }
     } else if ("bytea".equalsIgnoreCase(cellType.getOriginalTypeName())) {
-      binaryStream = rawData.getBinaryStream(columnName);
-      if (binaryStream != null) {
+      // bferreira, 2016-12-27 - do not use getBinaryStream in PostgreSQL,
+      // because the driver has a memory leak in that method (and then it uses
+      // some getBytes-equivalent method to fetch the data)
+      byte[] bytes = rawData.getBytes(columnName);
+      if (bytes != null) {
+        binaryStream = new ByteArrayInputStream(bytes);
         cell = new BinaryCell(id, binaryStream);
       } else {
         cell = new NullCell(id);

--- a/dbptk-modules/dbptk-module-siard/pom.xml
+++ b/dbptk-modules/dbptk-module-siard/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-siard</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-siard</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-solr/pom.xml
+++ b/dbptk-modules/dbptk-module-solr/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-solr</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-solr</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-sql-file/pom.xml
+++ b/dbptk-modules/dbptk-module-sql-file/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-sql-file</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-sql-file</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-sql-server/pom.xml
+++ b/dbptk-modules/dbptk-module-sql-server/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-sql-server</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-sql-server</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/pom.xml
+++ b/dbptk-modules/pom.xml
@@ -5,11 +5,11 @@
     <name>dbptk-modules</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-modules</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.3</version>
+        <version>2.0.0-beta6.4</version>
         <relativePath>..</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Database Preservation Toolkit</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk</artifactId>
-    <version>2.0.0-beta6.3</version>
+    <version>2.0.0-beta6.4</version>
     <packaging>pom</packaging>
     <description>A toolkit that allows data migration and conversion between database management systems formats and
         digital preservation formats.
@@ -184,12 +184,12 @@
             <dependency>
                 <groupId>com.databasepreservation</groupId>
                 <artifactId>dbptk-model</artifactId>
-                <version>2.0.0-beta6.3</version>
+                <version>2.0.0-beta6.4</version>
             </dependency>
             <dependency>
                 <groupId>com.databasepreservation</groupId>
                 <artifactId>dbptk-model</artifactId>
-                <version>2.0.0-beta6.3</version>
+                <version>2.0.0-beta6.4</version>
                 <classifier>sources</classifier>
             </dependency>
 
@@ -206,32 +206,32 @@
             </dependency>
 
             <!-- modules (with sources) -->
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siard1</artifactId><version>1.1.1</version></dependency>
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siard1</artifactId><version>1.1.1</version><classifier>sources</classifier></dependency>
@@ -242,14 +242,14 @@
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siarddk</artifactId><version>1.3.0</version></dependency>
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siarddk</artifactId><version>1.3.0</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.3</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.3</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.4</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
 
 
             <!-- plugin modules handling -->


### PR DESCRIPTION
By reducing the fetch size to a minimum if an out of memory error happens.

Note: the whole row is still kept in memory (and hopefully not duplicated somewhere in postgres jdbc implementation) as I could not find a way to have postgres retrieve less than a row at a time.