### PR TITLE
Better handling of fetch sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,34 +208,7 @@ Other related publications:
 
 ## Troubleshooting
 
-**Getting exception "java.net.ConnectException: Connection refused"**
-
-Most databases are not configured by default to allow TCP/IP connections. Check your database configuration if it accepts TCP/IP connection and if your IP address is allowed to connect. Also, ensure that the user has permissions to access the database from your IP address.
-
-**Problems importing from Microsoft Access**
-
-To import from Microsoft Access you need to be on a Windows machine with Microsoft Access installed. This is because the current Microsoft Access import module is implemented using ODBC connection. Therefore, you need Windows installed to be able to use ODBC. Also, you need Microsoft Access installed so its ODBC driver is installed on your system.
-
-Furthermore, in order to extract DB structures we need to have access to the internal database table `Msysrelationships`. You need to perform some hacking over the DBMS and this is version dependent. Please follow the instructions described on Microsoft's white paper, which explains how to do this for all Microsoft Access versions: ["Preparing a Microsoft Access Database for Migration"](http://rawgithub.com/keeps/db-preservation-toolkit/master/doc/Preparing_MSAccess_for_Migration.pdf).
-
-**Got error "java.lang.OutOfMemoryError: Java heap space"**
-
-The toolkit might need more memory than it is available by default (normally 64MB). To increase the available memory use the `-Xmx` option. For example, the following command will increase the heap size to 3 GB.
-
-```text
-$ java -Xmx3g -jar dbptk-app-x.y.z.jar ...
-```
-
-The toolkit needs enough memory to put the table structure definition in memory (not the data) and to load each data row or row set, which might include having some BLOBs completely in memory, but this depends on the database driver implementation.
-
-**Main hard drive gets full due to temporary files**
-
-Due to the structure of some export modules (e.g. SIARD) and because we only want to pass throught the database once with minimum amount of used memory, all BLOBs and CLOBs of a database table must be kept on temporary files during the export of a table. This can cause your main disk to get full and the execution to fail. To select a diferent folder for the temporary files, e.g. on a bigger hard drive, use the option `-Djava.io.tmpdir=/path/to/tmpdir`. For example, the following command will use the folder `/media/BIGHD/tmp` as the temporary folder:
-
-```text
-$ java -Djava.io.tmpdir=/media/BIGHD/tmp -jar dbptk-app-x.y.z.jar ...
-```
-
+Troubleshooting information can be found in a separate [Troubleshooting](https://github.com/keeps/db-preservation-toolkit/wiki/Troubleshooting) page.
 
 ## Information & Commercial support
 

--- a/dbptk-bindings/pom.xml
+++ b/dbptk-bindings/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/dbptk-core/pom.xml
+++ b/dbptk-core/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-core</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-core</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
     <properties>

--- a/dbptk-core/src/main/java/com/databasepreservation/Main.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/Main.java
@@ -94,6 +94,7 @@ public class Main {
     }
 
     Reporter.finish();
+    LOGGER.info("Troubleshooting information can be found at http://www.database-preservation.com/#troubleshooting");
     LOGGER.info("Please report any problems at https://github.com/keeps/db-preservation-toolkit/issues/new");
     logProgramFinish(exitStatus);
 

--- a/dbptk-model/pom.xml
+++ b/dbptk-model/pom.xml
@@ -5,12 +5,12 @@
     <name>dbptk-model</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-model</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/dbptk-model/src/main/java/com/databasepreservation/utils/ConfigUtils.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/utils/ConfigUtils.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Obtain values from system environment variables.
+ * Obtain values from system environment variables or properties.
  * 
  * @author Bruno Ferreira <bferreira@keep.pt>
  */
@@ -18,25 +18,59 @@ public class ConfigUtils {
     return StringUtils.join(parts, '_').toUpperCase(Locale.ENGLISH);
   }
 
+  private static String partsToProperty(String... parts) {
+    return StringUtils.join(parts, '.').toLowerCase(Locale.ENGLISH);
+  }
+
+  /**
+   * Same as getProperty(String defaultValue, String... parts), but attempts to
+   * convert the String values to Integers via Integer.parseInt
+   */
   public static Integer getProperty(Integer defaultValue, String... parts) {
     return Integer.parseInt(getProperty(defaultValue.toString(), parts));
   }
 
+  /**
+   * Get the value from the java properties (-Dxxx=yyy) or an environment
+   * variable (in that order), ultimately returning the default value if one was
+   * not found.
+   * 
+   * @param defaultValue
+   *          the value to return if no other value is found
+   * @param parts
+   *          used to build the environment variable and property names. Ex:
+   *          ["dbptk", "test"] becomes the environment variable "DBPTK_TEST"
+   *          and the property "dbptk.test"
+   * @return the value associated with the java property, OR the value
+   *         associated with the environment variable, OR the default value (in
+   *         this order).
+   */
   public static String getProperty(String defaultValue, String... parts) {
-    String envKey = partsToEnvironment(parts);
+    String propKey = partsToProperty(parts);
 
-    String value = retrievedProperties.get(envKey);
+    String value = retrievedProperties.get(propKey);
+    if (StringUtils.isNotBlank(value)) {
+      return value;
+    }
+
+    value = System.getProperty(propKey, null);
+    if (StringUtils.isNotBlank(value)) {
+      retrievedProperties.put(propKey, value);
+      return value;
+    }
+
+    String envKey = partsToEnvironment(parts);
     if (StringUtils.isNotBlank(value)) {
       return value;
     }
 
     value = System.getenv(envKey);
     if (StringUtils.isNotBlank(value)) {
-      retrievedProperties.put(envKey, value);
+      retrievedProperties.put(propKey, value);
       return value;
     }
 
-    retrievedProperties.put(envKey, defaultValue);
+    retrievedProperties.put(propKey, defaultValue);
     return defaultValue;
   }
 }

--- a/dbptk-model/src/main/java/com/databasepreservation/utils/ConfigUtils.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/utils/ConfigUtils.java
@@ -1,0 +1,42 @@
+package com.databasepreservation.utils;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Obtain values from system environment variables.
+ * 
+ * @author Bruno Ferreira <bferreira@keep.pt>
+ */
+public class ConfigUtils {
+  private static final Map<String, String> retrievedProperties = new HashMap<>();
+
+  private static String partsToEnvironment(String... parts) {
+    return StringUtils.join(parts, '_').toUpperCase(Locale.ENGLISH);
+  }
+
+  public static Integer getProperty(Integer defaultValue, String... parts) {
+    return Integer.parseInt(getProperty(defaultValue.toString(), parts));
+  }
+
+  public static String getProperty(String defaultValue, String... parts) {
+    String envKey = partsToEnvironment(parts);
+
+    String value = retrievedProperties.get(envKey);
+    if (StringUtils.isNotBlank(value)) {
+      return value;
+    }
+
+    value = System.getenv(envKey);
+    if (StringUtils.isNotBlank(value)) {
+      retrievedProperties.put(envKey, value);
+      return value;
+    }
+
+    retrievedProperties.put(envKey, defaultValue);
+    return defaultValue;
+  }
+}

--- a/dbptk-modules/dbptk-module-db2/pom.xml
+++ b/dbptk-modules/dbptk-module-db2/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-db2</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-db2</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-jdbc/pom.xml
+++ b/dbptk-modules/dbptk-module-jdbc/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-jdbc</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-jdbc</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-list-tables/pom.xml
+++ b/dbptk-modules/dbptk-module-list-tables/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-list-tables</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-list-tables</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-ms-access/pom.xml
+++ b/dbptk-modules/dbptk-module-ms-access/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-ms-access</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-ms-access</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/in/MsAccessUCanAccessImportModule.java
+++ b/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/in/MsAccessUCanAccessImportModule.java
@@ -45,14 +45,9 @@ public class MsAccessUCanAccessImportModule extends JDBCImportModule {
 
   @Override
   protected ResultSet getTableRawData(TableStructure table) throws SQLException, ModuleException {
-    String tableId;
-    ResultSet set = null;
-    tableId = table.getId();
-    LOGGER.debug("query: " + sqlHelper.selectTableSQL(tableId));
-    set = getStatement().executeQuery(sqlHelper.selectTableSQL(tableId));
-    set.setFetchSize(ROW_FETCH_BLOCK_SIZE);
-
-    return set;
+    String query = sqlHelper.selectTableSQL(table.getId());
+    LOGGER.debug("query: " + query);
+    return getTableRawData(query, table.getId());
   }
 
   /**

--- a/dbptk-modules/dbptk-module-mysql/pom.xml
+++ b/dbptk-modules/dbptk-module-mysql/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-mysql</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-mysql</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-odbc/pom.xml
+++ b/dbptk-modules/dbptk-module-odbc/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-odbc</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-odbc</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-oracle/pom.xml
+++ b/dbptk-modules/dbptk-module-oracle/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-oracle</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-oracle</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-postgresql/pom.xml
+++ b/dbptk-modules/dbptk-module-postgresql/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-postgresql</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-postgresql</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
+++ b/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgreSql/in/PostgreSQLJDBCImportModule.java
@@ -24,7 +24,6 @@ import org.postgresql.core.Oid;
 import org.postgresql.jdbc.PgResultSet;
 import org.postgresql.largeobject.LargeObject;
 import org.postgresql.largeobject.LargeObjectManager;
-import org.postgresql.util.PSQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,29 +172,7 @@ public class PostgreSQLJDBCImportModule extends JDBCImportModule {
     // use a high fetchSize, reducing it if it proves to be too high
     // since you are reading this, you might as well check if this related pull
     // request https://github.com/pgjdbc/pgjdbc/pull/675 has already been merged
-    int fetchSize = 200;
-    Statement st = getStatement();
-    while (fetchSize > 0) {
-      st.setFetchSize(fetchSize);
-      try {
-        return st.executeQuery(query.toString());
-      } catch (PSQLException psqlException) {
-        if (psqlException.getCause() instanceof OutOfMemoryError) {
-          LOGGER.debug("FetchSize of {} resulted in out of memory", fetchSize, psqlException);
-          if (fetchSize > 1) {
-            fetchSize = 1;
-          } else {
-            fetchSize = 0;
-          }
-        } else {
-          throw psqlException;
-        }
-      }
-    }
-    Reporter.customMessage(this.getClass().getName(), "Could not retrieve all data from table '" + table.getId()
-      + "' due to insufficient memory.");
-    throw new ModuleException("Out of memory while trying to fetch table '" + table.getId()
-      + "' data. More information at www.database-preservation.com");
+    return getTableRawData(query.toString(), table.getId());
   }
 
   /**

--- a/dbptk-modules/dbptk-module-siard/pom.xml
+++ b/dbptk-modules/dbptk-module-siard/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-siard</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-siard</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-solr/pom.xml
+++ b/dbptk-modules/dbptk-module-solr/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-solr</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-solr</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-sql-file/pom.xml
+++ b/dbptk-modules/dbptk-module-sql-file/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-sql-file</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-sql-file</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/dbptk-module-sql-server/pom.xml
+++ b/dbptk-modules/dbptk-module-sql-server/pom.xml
@@ -6,11 +6,11 @@
     <name>dbptk-module-sql-server</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-module-sql-server</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk-modules</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/dbptk-modules/pom.xml
+++ b/dbptk-modules/pom.xml
@@ -5,11 +5,11 @@
     <name>dbptk-modules</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk-modules</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <parent>
         <groupId>com.databasepreservation</groupId>
         <artifactId>dbptk</artifactId>
-        <version>2.0.0-beta6.4</version>
+        <version>2.0.0-beta6.5</version>
         <relativePath>..</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Database Preservation Toolkit</name>
     <groupId>com.databasepreservation</groupId>
     <artifactId>dbptk</artifactId>
-    <version>2.0.0-beta6.4</version>
+    <version>2.0.0-beta6.5</version>
     <packaging>pom</packaging>
     <description>A toolkit that allows data migration and conversion between database management systems formats and
         digital preservation formats.
@@ -184,12 +184,12 @@
             <dependency>
                 <groupId>com.databasepreservation</groupId>
                 <artifactId>dbptk-model</artifactId>
-                <version>2.0.0-beta6.4</version>
+                <version>2.0.0-beta6.5</version>
             </dependency>
             <dependency>
                 <groupId>com.databasepreservation</groupId>
                 <artifactId>dbptk-model</artifactId>
-                <version>2.0.0-beta6.4</version>
+                <version>2.0.0-beta6.5</version>
                 <classifier>sources</classifier>
             </dependency>
 
@@ -206,32 +206,32 @@
             </dependency>
 
             <!-- modules (with sources) -->
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-db2</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-jdbc</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-list-tables</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-ms-access</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-mysql</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-odbc</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-oracle</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-postgresql</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-siard</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siard1</artifactId><version>1.1.1</version></dependency>
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siard1</artifactId><version>1.1.1</version><classifier>sources</classifier></dependency>
@@ -242,14 +242,14 @@
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siarddk</artifactId><version>1.3.0</version></dependency>
             <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-bindings-siarddk</artifactId><version>1.3.0</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-solr</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-file</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.4</version></dependency>
-            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.4</version><classifier>sources</classifier></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.5</version></dependency>
+            <dependency><groupId>com.databasepreservation</groupId><artifactId>dbptk-module-sql-server</artifactId><version>2.0.0-beta6.5</version><classifier>sources</classifier></dependency>
 
 
             <!-- plugin modules handling -->


### PR DESCRIPTION
**Adaptive row fetch size** (number of rows fetched from the database at once):

1. starting with the default value suggested/calculated by the driver
2. using a fetch size of 10
3. using a fetch size of 1

However, some drivers do not handle this change correctly and end up skipping some rows. E.g. if an out of memory error happens on the 5th row of a 10 row fetch, 5 rows may be lost as the driver starts obtaining the next 10 rows and ignores the 5 rows that were not processed.

**Setting properties from the command line**:

* `dbptk.jdbc.fetchsize.default` (Integer) - the first fetch size to try
* `dbptk.jdbc.fetchsize.small` (Integer) - the second fetch size to try, in case the first one caused an issue
* `dbptk.jdbc.fetchsize.minimum` (Integer) - the last fetch size to try before giving up on fetching information from this table

These settings may also be set as environment variables:

* `DBPTK_JDBC_FETCHSIZE_DEFAULT`
* `DBPTK_JDBC_FETCHSIZE_SMALL`
* `DBPTK_JDBC_FETCHSIZE_MINIMUM`