### PR TITLE
Refactor: cell value strip trailing

### DIFF
--- a/dbptk-modules/dbptk-filter-external-lobs/src/main/java/com/databasepreservation/modules/externalLobs/CellHandlers/ExternalLOBSCellHandlerFileSystem.java
+++ b/dbptk-modules/dbptk-filter-external-lobs/src/main/java/com/databasepreservation/modules/externalLobs/CellHandlers/ExternalLOBSCellHandlerFileSystem.java
@@ -40,7 +40,9 @@ public class ExternalLOBSCellHandlerFileSystem implements ExternalLOBSCellHandle
       return newCell;
     }
 
-    Path blobPath = basePath.resolve(cellValue);
+    String cellValueStripTrailing = cellValue.stripTrailing();
+
+    Path blobPath = basePath.resolve(cellValueStripTrailing);
 
     if (Files.exists(blobPath)) {
       if (Files.isRegularFile(blobPath)) {
@@ -48,15 +50,15 @@ public class ExternalLOBSCellHandlerFileSystem implements ExternalLOBSCellHandle
               newCell = new BinaryCell(cellId, new PathInputStreamProvider(blobPath));
           } catch (ModuleException e) {
               reporter.ignored("Cell " + cellId,
-                      blobPath.toString() + " ignore due to: " + e.getMessage() + "; Base path: " + this.basePath + " Cell Value: " + cellValue);
+                      blobPath.toString() + " ignore due to: " + e.getMessage() + "; Base path: " + this.basePath + " Cell Value: " + cellValueStripTrailing);
           }
       } else {
         reporter.ignored("Cell " + cellId,
-          blobPath.toString() + " is not a file; Base path: " + this.basePath + " Cell Value: " + cellValue);
+          blobPath.toString() + " is not a file; Base path: " + this.basePath + " Cell Value: " + cellValueStripTrailing);
       }
     } else {
       reporter.ignored("Cell " + cellId, "Path: " + blobPath.toString() + " could not be found; Base path: "
-        + this.basePath + " Cell Value: " + cellValue);
+        + this.basePath + " Cell Value: " + cellValueStripTrailing);
     }
     return newCell;
   }


### PR DESCRIPTION
Some cells have a fixed character length, which results in padding with trailing spaces when the value is shorter than the limit. 

This pull request refactors the code that extracts cell values to automatically trim these unnecessary spaces.